### PR TITLE
Add `environment` property to context

### DIFF
--- a/src/Configuration/Context.php
+++ b/src/Configuration/Context.php
@@ -4,7 +4,9 @@ namespace Unleash\Client\Configuration;
 
 /**
  * @method string|null getHostname()
+ * @method string|null getEnvironment()
  * @method Context     setHostname(string|null $hostname)
+ * @method Context     setEnvironment(string|null $environment)
  */
 interface Context
 {

--- a/src/Configuration/UnleashContext.php
+++ b/src/Configuration/UnleashContext.php
@@ -17,6 +17,7 @@ final class UnleashContext implements Context
         private ?string $sessionId = null,
         private array $customContext = [],
         ?string $hostname = null,
+        private ?string $environment = null,
     ) {
         $this->setHostname($hostname);
     }
@@ -24,6 +25,11 @@ final class UnleashContext implements Context
     public function getCurrentUserId(): ?string
     {
         return $this->currentUserId;
+    }
+
+    public function getEnvironment(): ?string
+    {
+        return $this->environment;
     }
 
     public function getIpAddress(): ?string
@@ -89,6 +95,13 @@ final class UnleashContext implements Context
         return $this;
     }
 
+    public function setEnvironment(?string $environment): self
+    {
+        $this->environment = $environment;
+
+        return $this;
+    }
+
     public function getHostname(): ?string
     {
         return $this->findContextValue('hostname') ?? (gethostname() ?: null);
@@ -124,6 +137,7 @@ final class UnleashContext implements Context
             ContextField::USER_ID, Stickiness::USER_ID => $this->getCurrentUserId(),
             ContextField::SESSION_ID, Stickiness::SESSION_ID => $this->getSessionId(),
             ContextField::IP_ADDRESS => $this->getIpAddress(),
+            ContextField::ENVIRONMENT => $this->getEnvironment(),
             default => $this->customContext[$fieldName] ?? null,
         };
     }

--- a/src/Enum/ContextField.php
+++ b/src/Enum/ContextField.php
@@ -10,5 +10,7 @@ final class ContextField
 
     public const IP_ADDRESS = 'remoteAddress';
 
+    public const ENVIRONMENT = 'environment';
+
     public const REMOTE_ADDRESS = self::IP_ADDRESS;
 }

--- a/tests/ClientSpecificationTest.php
+++ b/tests/ClientSpecificationTest.php
@@ -94,6 +94,7 @@ final class ClientSpecificationTest extends AbstractHttpClientTest
         $contextObject = (new UnleashContext())
             ->setCurrentUserId($context['userId'] ?? null)
             ->setSessionId($context['sessionId'] ?? null)
+            ->setEnvironment($context['environment'] ?? null)
             ->setIpAddress($context['remoteAddress'] ?? '');
 
         if (isset($context['properties'])) {

--- a/tests/Configuration/UnleashContextTest.php
+++ b/tests/Configuration/UnleashContextTest.php
@@ -62,7 +62,7 @@ final class UnleashContextTest extends TestCase
     {
         unset($_SERVER['REMOTE_ADDR']);
 
-        $context = (new UnleashContext('123', '456', '789'))
+        $context = (new UnleashContext('123', '456', '789', [], null, 'dev'))
             ->setCustomProperty('someField', '012');
 
         self::assertTrue($context->hasMatchingFieldValue(ContextField::USER_ID, [
@@ -76,6 +76,10 @@ final class UnleashContextTest extends TestCase
         self::assertTrue($context->hasMatchingFieldValue(ContextField::SESSION_ID, [
             '852',
             '789',
+        ]));
+        self::assertTrue($context->hasMatchingFieldValue(ContextField::ENVIRONMENT, [
+            'dev',
+            'production',
         ]));
         self::assertTrue($context->hasMatchingFieldValue('someField', [
             '753',

--- a/tests/ContextProvider/DefaultUnleashContextProviderTest.php
+++ b/tests/ContextProvider/DefaultUnleashContextProviderTest.php
@@ -17,26 +17,29 @@ final class DefaultUnleashContextProviderTest extends TestCase
         self::assertNull($instance->getContext()->getCurrentUserId());
         self::assertNull($instance->getContext()->getIpAddress());
         self::assertNull($instance->getContext()->getSessionId());
+        self::assertNull($instance->getContext()->getEnvironment());
         self::assertNotSame($instance->getContext(), $instance->getContext());
 
-        $instance = new DefaultUnleashContextProvider(new UnleashContext('123', '456', '789'));
+        $instance = new DefaultUnleashContextProvider(new UnleashContext('123', '456', '789', [], null, 'dev'));
         self::assertInstanceOf(UnleashContext::class, $instance->getContext());
         self::assertEquals('123', $instance->getContext()->getCurrentUserId());
         self::assertEquals('456', $instance->getContext()->getIpAddress());
         self::assertEquals('789', $instance->getContext()->getSessionId());
+        self::assertEquals('dev', $instance->getContext()->getEnvironment());
         self::assertNotSame($instance->getContext(), $instance->getContext());
     }
 
     public function testSetDefaultContext()
     {
         $instance = new DefaultUnleashContextProvider();
-        $context = new UnleashContext('123', '456', '789');
+        $context = new UnleashContext('123', '456', '789', [], null, 'dev');
         $instance->setDefaultContext($context);
 
         self::assertInstanceOf(UnleashContext::class, $instance->getContext());
         self::assertEquals('123', $instance->getContext()->getCurrentUserId());
         self::assertEquals('456', $instance->getContext()->getIpAddress());
         self::assertEquals('789', $instance->getContext()->getSessionId());
+        self::assertEquals('dev', $instance->getContext()->getEnvironment());
         self::assertNotSame($instance->getContext(), $instance->getContext());
     }
 }


### PR DESCRIPTION
Add  the `environment` property to context to be able to: 
1. Use the [Constrain on a specific environment](https://docs.getunleash.io/advanced/strategy_constraints#constrain-on-a-specific-environment) 
2. Create custom strategies based on the environment.