### PR TITLE
Use php-http/discovery to find PSR-17/18 implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,11 @@ Some optional parameters can be set, these include:
 - available strategies
 - http headers
 
-If you use [guzzlehttp/guzzle](https://packagist.org/packages/guzzlehttp/guzzle) or
+The builder will attempt to load http client and request factory implementations automatically. Most implementations,
+such as [guzzlehttp/guzzle](https://packagist.org/packages/guzzlehttp/guzzle) or
 [symfony/http-client](https://packagist.org/packages/symfony/http-client) (in combination with 
-[nyholm/psr7](https://packagist.org/packages/nyholm/psr7)), the http client and request factory will be created 
-automatically, otherwise you need to provide an implementation on your own.
+[nyholm/psr7](https://packagist.org/packages/nyholm/psr7)), will be loaded automatically. If the builder is unable to
+locate a http client or request factory implementation, you will need to provide some implementation on your own.
 
 If you use [symfony/cache](https://packagist.org/packages/symfony/cache) or
 [cache/filesystem-adapter](https://packagist.org/packages/cache/filesystem-adapter) as your cache implementation, the

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ $builder = UnleashBuilder::create()
 
 Some optional parameters can be set, these include:
 
-- http client implementation
-- request factory implementation
+- http client implementation ([PSR-18](https://packagist.org/providers/psr/http-client-implementation))
+- request factory implementation ([PSR-17](https://packagist.org/providers/psr/http-factory-implementation))
 - cache implementation ([PSR-16](https://packagist.org/providers/psr/simple-cache-implementation))
 - cache ttl
 - available strategies

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "psr/simple-cache": "^1.0",
         "psr/simple-cache-implementation": "^1.0",
         "lastguest/murmurhash": "^2.1",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0",
+        "php-http/discovery": "^1.14"
     },
     "autoload": {
         "psr-4": {

--- a/src/Helper/DefaultImplementationLocator.php
+++ b/src/Helper/DefaultImplementationLocator.php
@@ -3,8 +3,9 @@
 namespace Unleash\Client\Helper;
 
 use Cache\Adapter\Filesystem\FilesystemCachePool;
-use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\HttpFactory;
+use Http\Discovery\Exception\NotFoundException;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
 use LogicException;
@@ -13,7 +14,6 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Psr16Cache;
-use Symfony\Component\HttpClient\Psr18Client;
 
 /**
  * @internal
@@ -42,14 +42,6 @@ final class DefaultImplementationLocator
      * @var array<string,array<string,array>>
      */
     private array $defaultImplementations = [
-        'client' => [
-            Client::class => [],
-            Psr18Client::class => [],
-        ],
-        'factory' => [
-            HttpFactory::class => [],
-            Psr18Client::class => [],
-        ],
         'cache' => [
             FilesystemCachePool::class => [
                 Filesystem::class => [
@@ -68,40 +60,35 @@ final class DefaultImplementationLocator
 
     public function findHttpClient(): ?ClientInterface
     {
-        foreach ($this->defaultImplementations['client'] as $class => $config) {
-            if (class_exists($class)) {
-                $result = $this->constructObject($class, $config);
-                if (!$result instanceof ClientInterface) {
-                    // @codeCoverageIgnoreStart
-                    throw new LogicException('The resulting object is not an instance of ' . ClientInterface::class);
-                    // @codeCoverageIgnoreEnd
-                }
-
-                return $result;
-            }
+        try {
+            /**
+             * Discovery triggers an error if symfony/http-client is installed
+             * and php-http/httplug is not, even if the intention is to find a
+             * PSR-18 client. Since the discovery will otherwise be successful,
+             * let's silence the error.
+             */
+            return @Psr18ClientDiscovery::find();
+        } catch (NotFoundException $e) {
+            return null;
         }
-
-        return null;
     }
 
     public function findRequestFactory(): ?RequestFactoryInterface
     {
-        foreach ($this->defaultImplementations['factory'] as $class => $config) {
-            if (class_exists($class)) {
-                $result = $this->constructObject($class, $config);
-                if (!$result instanceof RequestFactoryInterface) {
-                    // @codeCoverageIgnoreStart
-                    throw new LogicException(
-                        'The resulting object is not an instance of ' . RequestFactoryInterface::class
-                    );
-                    // @codeCoverageIgnoreEnd
-                }
-
-                return $result;
-            }
+        try {
+            return Psr17FactoryDiscovery::findRequestFactory();
+            // @codeCoverageIgnoreStart
+        } catch (NotFoundException $e) {
+            /**
+             * This will only be thrown if a HTTP client was found, but a request factory is not.
+             * Due to how php-http/discovery works, this scenario is unlikely to happen.
+             * See linked comment for more info.
+             *
+             * https://github.com/Unleash/unleash-client-php/pull/27#issuecomment-920764416
+             */
+            return null;
+            // @codeCoverageIgnoreEnd
         }
-
-        return null;
     }
 
     public function findCache(): ?CacheInterface

--- a/src/Helper/DefaultImplementationLocator.php
+++ b/src/Helper/DefaultImplementationLocator.php
@@ -24,14 +24,6 @@ final class DefaultImplementationLocator
      * @var array<string,string[]>
      */
     private array $supportedPackages = [
-        'client' => [
-            'guzzlehttp/guzzle',
-            'symfony/http-client',
-        ],
-        'factory' => [
-            'guzzlehttp/guzzle',
-            'symfony/http-client',
-        ],
         'cache' => [
             'symfony/cache',
             'cache/filesystem-adapter',
@@ -109,22 +101,6 @@ final class DefaultImplementationLocator
         }
 
         return null;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getHttpClientPackages(): array
-    {
-        return $this->supportedPackages['client'];
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getRequestFactoryPackages(): array
-    {
-        return $this->supportedPackages['factory'];
     }
 
     /**

--- a/src/UnleashBuilder.php
+++ b/src/UnleashBuilder.php
@@ -286,6 +286,14 @@ final class UnleashBuilder
         $requestFactory = $this->requestFactory;
         if ($requestFactory === null) {
             $requestFactory = $this->defaultImplementationLocator->findRequestFactory();
+            /**
+             * This will only be thrown if a HTTP client was found, but a request factory is not.
+             * Due to how php-http/discovery works, this scenario is unlikely to happen.
+             * See linked comment for more info.
+             *
+             * https://github.com/Unleash/unleash-client-php/pull/27#issuecomment-920764416
+             */
+            // @codeCoverageIgnoreStart
             if ($requestFactory === null) {
                 throw new InvalidValueException(
                     sprintf(
@@ -294,6 +302,7 @@ final class UnleashBuilder
                     )
                 );
             }
+            // @codeCoverageIgnoreEnd
         }
         assert($requestFactory instanceof RequestFactoryInterface);
 

--- a/src/UnleashBuilder.php
+++ b/src/UnleashBuilder.php
@@ -274,10 +274,7 @@ final class UnleashBuilder
             $httpClient = $this->defaultImplementationLocator->findHttpClient();
             if ($httpClient === null) {
                 throw new InvalidValueException(
-                    sprintf(
-                        "No http client provided, please use 'withHttpClient()' method or install one of officially supported clients: '%s'",
-                        implode("', '", $this->defaultImplementationLocator->getHttpClientPackages())
-                    )
+                    "No http client provided, please use 'withHttpClient()' method or install a package providing 'psr/http-client-implementation'.",
                 );
             }
         }
@@ -296,10 +293,7 @@ final class UnleashBuilder
             // @codeCoverageIgnoreStart
             if ($requestFactory === null) {
                 throw new InvalidValueException(
-                    sprintf(
-                        "No request factory provided, please use 'withHttpClient()' method or install one of officially supported clients: '%s'",
-                        implode("', '", $this->defaultImplementationLocator->getRequestFactoryPackages())
-                    )
+                    "No request factory provided, please use 'withRequestFactory()' method or install a package providing 'psr/http-factory-implementation'.",
                 );
             }
             // @codeCoverageIgnoreEnd


### PR DESCRIPTION
This project relies on PSR-17 request factories and PSR-18 HTTP clients to perform HTTP requests. It will load Guzzle and Symfony implementations if they exist, otherwise the user is required to provide their own.

Let's use [`php-http/discovery`](https://github.com/php-http/discovery) to load more PSR-17/18 implementations automatically. This will reduce the need for users to configure their own PSR-17/18 implementations manually.