### PR TITLE
Remove syntax error for php < 8

### DIFF
--- a/tests/Repository/DefaultUnleashRepositoryTest.php
+++ b/tests/Repository/DefaultUnleashRepositoryTest.php
@@ -225,7 +225,7 @@ final class DefaultUnleashRepositoryTest extends AbstractHttpClientTest
             (new UnleashConfiguration('', '', ''))
                 ->setCache($this->getCache())
                 ->setFetchingEnabled(false)
-                ->setBootstrapProvider(new JsonSerializableBootstrapProvider([])),
+                ->setBootstrapProvider(new JsonSerializableBootstrapProvider([]))
         );
 
         $this->expectException(InvalidValueException::class);


### PR DESCRIPTION
# Description

Syntax error in tests for php < 8.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [ ] Spec Tests
- [ ] Integration tests / Manual Tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
