### PR TITLE
Fix: Calling array_is_list on older versions of php

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,9 +57,12 @@ jobs:
         run: composer install
       - name: Transpile ${{ matrix.version }}
         run: php vendor/bin/rector process --no-diffs --no-progress-bar --config rector.$(echo ${{ matrix.version }} | sed -e 's/\.//').php src
-      - name: Add polyfill
+      - name: Add polyfill for 7.3
         if: matrix.version == '7.2'
         run: composer require symfony/polyfill-php73
+      - name: Add polyfill for 8.1
+        if: matrix.version == '7.2' || matrix.version == '7.3' || matrix.version == '7.4' || matrix.version == '8.0'
+        run: composer require symfony/polyfill-php81
       - name: Update composer.json version
         run: 'sed -i -e ''s/"php": "\^8.1"/"php": "\^${{ matrix.version }}"/'' composer.json'
       - name: Downgrade phpunit

--- a/.github/workflows/transpile.yaml
+++ b/.github/workflows/transpile.yaml
@@ -23,9 +23,12 @@ jobs:
         run: composer install
       - name: Transpile to ${{ matrix.version }}
         run: php vendor/bin/rector process --no-diffs --no-progress-bar --config rector.$(echo ${{ matrix.version }} | sed -e 's/\.//').php src
-      - name: Add polyfill
+      - name: Add polyfill for 7.3
         if: matrix.version == '7.2'
         run: composer require symfony/polyfill-php73
+      - name: Add polyfill for 8.1
+        if: matrix.version == '7.2' || matrix.version == '7.3' || matrix.version == '7.4' || matrix.version == '8.0'
+        run: composer require symfony/polyfill-php81
       - name: Update composer.json version
         run: 'sed -i -e ''s/"php": "\^8.1"/"php": "\^${{ matrix.version }}"/'' composer.json'
       - name: Downgrade phpunit

--- a/tests/ConstraintValidator/Operator/Lists/AbstractListOperatorValidatorTest.php
+++ b/tests/ConstraintValidator/Operator/Lists/AbstractListOperatorValidatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Unleash\Client\Tests\ConstraintValidator\Operator\Lists;
+
+use PHPUnit\Framework\TestCase;
+use Unleash\Client\ConstraintValidator\Operator\Lists\AbstractListOperatorValidator;
+
+final class AbstractListOperatorValidatorTest extends TestCase
+{
+    public function testAcceptsValues()
+    {
+        $instance = new class extends AbstractListOperatorValidator {
+            protected function validate(string $currentValue, $searchInValue): bool
+            {
+                return false;
+            }
+
+            public function acceptsValues($values): bool
+            {
+                return parent::acceptsValues($values);
+            }
+        };
+
+        self::assertTrue($instance->acceptsValues([1, 2, 3]));
+        self::assertTrue($instance->acceptsValues(['test1', 'test2', 'test3']));
+        self::assertTrue($instance->acceptsValues([0 => 'test1', 1 => 'test2', 2 => 'test3']));
+
+        self::assertFalse($instance->acceptsValues([1 => 1, 2 => 2, 3 => 3]));
+        self::assertFalse($instance->acceptsValues(['test1' => 'test1', 'test2' => 'test2', 'test3' => 'test3']));
+    }
+}


### PR DESCRIPTION
# Description

Adds polyfill for `array_is_list()`

Fixes #66 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [ ] Spec Tests
- [ ] Integration tests / Manual Tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
