### PR TITLE
Fix: Add a stub for Event class if it's not loaded

### DIFF
--- a/src/Event/FeatureToggleDisabledEvent.php
+++ b/src/Event/FeatureToggleDisabledEvent.php
@@ -2,10 +2,15 @@
 
 namespace Unleash\Client\Event;
 
+use Symfony\Contracts\EventDispatcher\Event;
 use Unleash\Client\Configuration\Context;
 use Unleash\Client\DTO\Feature;
 
-final class FeatureToggleDisabledEvent
+if (!class_exists(Event::class)) {
+    require __DIR__ . '/../../stubs/event-dispatcher/Event.php';
+}
+
+final class FeatureToggleDisabledEvent extends Event
 {
     /**
      * @internal

--- a/src/Event/FeatureToggleMissingStrategyHandlerEvent.php
+++ b/src/Event/FeatureToggleMissingStrategyHandlerEvent.php
@@ -2,10 +2,15 @@
 
 namespace Unleash\Client\Event;
 
+use Symfony\Contracts\EventDispatcher\Event;
 use Unleash\Client\Configuration\Context;
 use Unleash\Client\DTO\Feature;
 
-final class FeatureToggleMissingStrategyHandlerEvent
+if (!class_exists(Event::class)) {
+    require __DIR__ . '/../../stubs/event-dispatcher/Event.php';
+}
+
+final class FeatureToggleMissingStrategyHandlerEvent extends Event
 {
     /**
      * @internal

--- a/src/Event/FeatureToggleNotFoundEvent.php
+++ b/src/Event/FeatureToggleNotFoundEvent.php
@@ -5,6 +5,10 @@ namespace Unleash\Client\Event;
 use Symfony\Contracts\EventDispatcher\Event;
 use Unleash\Client\Configuration\Context;
 
+if (!class_exists(Event::class)) {
+    require __DIR__ . '/../../stubs/event-dispatcher/Event.php';
+}
+
 final class FeatureToggleNotFoundEvent extends Event
 {
     /**

--- a/stubs/event-dispatcher/Event.php
+++ b/stubs/event-dispatcher/Event.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Contracts\EventDispatcher;
+
+if (!class_exists(Event::class)) {
+    class Event
+    {
+    }
+}


### PR DESCRIPTION
# Description

Provides a fallback for Event class if event dispatcher is not installed.

Fixes #83 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Manual Tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
