### PR TITLE
Chore: Remove 8.1 polyfill

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,9 +60,6 @@ jobs:
       - name: Add polyfill for 7.3
         if: matrix.version == '7.2'
         run: composer require symfony/polyfill-php73
-      - name: Add polyfill for 8.1
-        if: matrix.version == '7.2' || matrix.version == '7.3' || matrix.version == '7.4' || matrix.version == '8.0'
-        run: composer require symfony/polyfill-php81
       - name: Update composer.json version
         run: 'sed -i -e ''s/"php": "\^8.1"/"php": "\^${{ matrix.version }}"/'' composer.json'
       - name: Downgrade phpunit

--- a/.github/workflows/transpile.yaml
+++ b/.github/workflows/transpile.yaml
@@ -26,9 +26,6 @@ jobs:
       - name: Add polyfill for 7.3
         if: matrix.version == '7.2'
         run: composer require symfony/polyfill-php73
-      - name: Add polyfill for 8.1
-        if: matrix.version == '7.2' || matrix.version == '7.3' || matrix.version == '7.4' || matrix.version == '8.0'
-        run: composer require symfony/polyfill-php81
       - name: Update composer.json version
         run: 'sed -i -e ''s/"php": "\^8.1"/"php": "\^${{ matrix.version }}"/'' composer.json'
       - name: Downgrade phpunit


### PR DESCRIPTION
# Description

Removes polyfill for php 8.1 which is not needed anymore as Rector can downgrade `array_is_list()` correctly.
