### PR TITLE
Fix: Don't throw on missing user ids

### DIFF
--- a/src/Strategy/UserIdStrategyHandler.php
+++ b/src/Strategy/UserIdStrategyHandler.php
@@ -4,17 +4,13 @@ namespace Unleash\Client\Strategy;
 
 use Unleash\Client\Configuration\Context;
 use Unleash\Client\DTO\Strategy;
-use Unleash\Client\Exception\MissingArgumentException;
 
 final class UserIdStrategyHandler extends AbstractStrategyHandler
 {
-    /**
-     * @throws MissingArgumentException
-     */
     public function isEnabled(Strategy $strategy, Context $context): bool
     {
         if (!$userIds = $this->findParameter('userIds', $strategy)) {
-            throw new MissingArgumentException("The remote server did not return 'userIds' config");
+            return false;
         }
         if ($context->getCurrentUserId() === null) {
             return false;

--- a/tests/Strategy/UserIdStrategyHandlerTest.php
+++ b/tests/Strategy/UserIdStrategyHandlerTest.php
@@ -7,7 +7,6 @@ use Unleash\Client\Configuration\UnleashContext;
 use Unleash\Client\DTO\DefaultConstraint;
 use Unleash\Client\DTO\DefaultStrategy;
 use Unleash\Client\Enum\ConstraintOperator;
-use Unleash\Client\Exception\MissingArgumentException;
 use Unleash\Client\Strategy\UserIdStrategyHandler;
 
 final class UserIdStrategyHandlerTest extends TestCase
@@ -31,13 +30,9 @@ final class UserIdStrategyHandlerTest extends TestCase
             'userIds' => '123',
         ]), new UnleashContext()));
 
-        try {
-            $instance->isEnabled(new DefaultStrategy('userWithId', [
-                'userIds' => '',
-            ]), new UnleashContext());
-            $this->fail('Expected exception of class ' . MissingArgumentException::class);
-        } catch (MissingArgumentException $ignored) {
-        }
+        self::assertFalse($instance->isEnabled(new DefaultStrategy('userWithId', [
+            'userIds' => '',
+        ]), new UnleashContext()));
 
         self::assertTrue($instance->isEnabled(new DefaultStrategy('userWithId', [
             'userIds' => '123,456',


### PR DESCRIPTION
# Description

SDK returns `false` on missing user id on server instead of throwing an exception.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
