### PR TITLE
Fix: Don't require latest version of polyfill

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
         run: php vendor/bin/rector process --no-diffs --no-progress-bar --config rector.$(echo ${{ matrix.version }} | sed -e 's/\.//').php src
       - name: Add polyfill for 7.3
         if: matrix.version == '7.2'
-        run: composer require symfony/polyfill-php73
+        run: composer require symfony/polyfill-php73:^1.0
       - name: Add polyfill for 8.1
         if: matrix.version == '7.2' || matrix.version == '7.3' || matrix.version == '7.4' || matrix.version == '8.0'
         run: composer require symfony/polyfill-php81

--- a/.github/workflows/transpile.yaml
+++ b/.github/workflows/transpile.yaml
@@ -25,7 +25,7 @@ jobs:
         run: php vendor/bin/rector process --no-diffs --no-progress-bar --config rector.$(echo ${{ matrix.version }} | sed -e 's/\.//').php src
       - name: Add polyfill for 7.3
         if: matrix.version == '7.2'
-        run: composer require symfony/polyfill-php73
+        run: composer require symfony/polyfill-php73:^1.0
       - name: Add polyfill for 8.1
         if: matrix.version == '7.2' || matrix.version == '7.3' || matrix.version == '7.4' || matrix.version == '8.0'
         run: composer require symfony/polyfill-php81


### PR DESCRIPTION
# Description

Don't require latest version of polyfill to not force consumers to upgrade it in case they use it already.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
