### PR TITLE
docs: update return type documentation

### DIFF
--- a/src/Helper/StringStream.php
+++ b/src/Helper/StringStream.php
@@ -48,7 +48,7 @@ final class StringStream implements StreamInterface
         return $content;
     }
 
-    public function close()
+    public function close(): void
     {
         if ($this->stream === null) {
             throw new StreamException('The stream is detached');
@@ -190,6 +190,7 @@ final class StringStream implements StreamInterface
         return $result;
     }
 
+    /** @return mixed */
     public function getMetadata($key = null)
     {
         if ($this->stream === null) {

--- a/src/Helper/StringStream.php
+++ b/src/Helper/StringStream.php
@@ -190,8 +190,7 @@ final class StringStream implements StreamInterface
         return $result;
     }
 
-    /** @return mixed */
-    public function getMetadata($key = null)
+    public function getMetadata($key = null): mixed
     {
         if ($this->stream === null) {
             throw new StreamException('The stream is detached');


### PR DESCRIPTION
# Description

This addresses deprecation warnings from Symfony regarding return types.

~~To ensure that this remains compatible with previous versions of PHP, a doc block type annotation is used for `getMetadata` instead of using type hinting with the native `mixed` pseudo type introduced in PHP 8.0~~
PHP 8.1 is the currently supported version of PHP so it is fine to use the `mixed` pseudo type.

## Type of change

Misc: Type annotation and documentation update.

# How Has This Been Tested?

As this does not modify the functionality of the code, no additional tests have been added.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
