### PR TITLE
Fix: Allow all event dispatchers

### DIFF
--- a/src/Helper/EventDispatcher.php
+++ b/src/Helper/EventDispatcher.php
@@ -2,9 +2,7 @@
 
 namespace Unleash\Client\Helper;
 
-use InvalidArgumentException;
 use JetBrains\PhpStorm\ExpectedValues;
-use Symfony\Component\EventDispatcher\EventDispatcher as SymfonyEventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Unleash\Client\Event\UnleashEvents;
@@ -21,15 +19,11 @@ if (!interface_exists(EventDispatcherInterface::class)) {
 final class EventDispatcher implements EventDispatcherInterface
 {
     /**
-     * @param SymfonyEventDispatcher|null $eventDispatcher
-     * @noinspection PhpDocSignatureInspection
+     * @param EventDispatcherInterface|null $eventDispatcher
      */
     public function __construct(
-        private readonly ?object $eventDispatcher,
+        private readonly ?EventDispatcherInterface $eventDispatcher,
     ) {
-        if ($this->eventDispatcher !== null && !$this->eventDispatcher instanceof SymfonyEventDispatcher) { // @phpstan-ignore-line
-            throw new InvalidArgumentException('The dispatcher must either be null or an instance of ' . SymfonyEventDispatcher::class);
-        }
     }
 
     public function addListener(string $eventName, callable $listener, int $priority = 0): void

--- a/src/UnleashBuilder.php
+++ b/src/UnleashBuilder.php
@@ -11,6 +11,7 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Psr\SimpleCache\CacheInterface;
 use SplFileInfo;
 use Symfony\Component\EventDispatcher\EventDispatcher as SymfonyEventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Traversable;
 use Unleash\Client\Bootstrap\BootstrapHandler;
@@ -93,7 +94,7 @@ final class UnleashBuilder
     private array $strategies;
 
     /**
-     * @var SymfonyEventDispatcher|null
+     * @var EventDispatcherInterface|null
      * @noinspection PhpDocFieldTypeMismatchInspection
      */
     private ?object $eventDispatcher = null;
@@ -306,7 +307,7 @@ final class UnleashBuilder
     }
 
     #[Pure]
-    public function withEventDispatcher(?SymfonyEventDispatcher $eventDispatcher): self
+    public function withEventDispatcher(?EventDispatcherInterface $eventDispatcher): self
     {
         return $this->with('eventDispatcher', $eventDispatcher);
     }

--- a/tests/Helper/EventDispatcherTest.php
+++ b/tests/Helper/EventDispatcherTest.php
@@ -2,7 +2,6 @@
 
 namespace Unleash\Client\Tests\Helper;
 
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\EventDispatcher\EventDispatcher as SymfonyEventDispatcher;

--- a/tests/Helper/EventDispatcherTest.php
+++ b/tests/Helper/EventDispatcherTest.php
@@ -97,12 +97,4 @@ final class EventDispatcherTest extends TestCase
         self::assertTrue($instance->hasListeners('test2'));
         self::assertFalse($instance->hasListeners('test3'));
     }
-
-    public function testInvalidClass()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        // it's typehinted as any object due to event dispatcher being non-mandatory,
-        // but it shouldn't really accept any class
-        new EventDispatcher(new stdClass());
-    }
 }

--- a/tests/UnleashBuilderTest.php
+++ b/tests/UnleashBuilderTest.php
@@ -304,6 +304,7 @@ final class UnleashBuilderTest extends TestCase
             ->withAppUrl('http://example.com')
             ->withInstanceId('test')
             ->withAppName('test')
+            ->withAutomaticRegistrationEnabled(false)
         ;
         $unleash = $instance->build();
 


### PR DESCRIPTION
# Description

Allows instances of EventDispatcherInterface to be used instead of single concrete class.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
