### PR TITLE
Feat: Add stale cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,11 @@ It would be slow to perform a http request every time you check if a feature is 
 apps. That's why this library has built-in support for PSR-16 cache implementations.
 
 If you don't provide any implementation and default implementation exists, it's used, otherwise you'll get an exception.
-You can also provide a TTL which defaults to 30 seconds.
+You can also provide a TTL which defaults to 30 seconds for standard cache and 30 minutes for stale data cache.
+
+> Stale data cache is used when http communication fails while fetching feature list from the server. In that case
+> the latest valid version is used until the TTL expires or server starts responding again. An event gets emitted
+> when this happens, for more information see [events documentation](doc/events.md).
 
 Cache implementations supported out of the box (meaning you don't need to configure anything):
 
@@ -250,7 +254,9 @@ $builder = UnleashBuilder::create()
             new Local(sys_get_temp_dir()),
         ),
     ))
-    ->withCacheTimeToLive(120);
+    ->withCacheTimeToLive(120)
+    ->withStaleTtl(300)
+;
 
 // you can set the cache handler explicitly to null to revert back to autodetection
 

--- a/doc/events.md
+++ b/doc/events.md
@@ -20,6 +20,7 @@ use Unleash\Client\Event\FeatureToggleDisabledEvent;
 use Unleash\Client\Event\FeatureToggleMissingStrategyHandlerEvent;
 use Unleash\Client\Event\FeatureToggleNotFoundEvent;
 use Unleash\Client\Event\FeatureVariantBeforeFallbackReturnedEvent;
+use Unleash\Client\Event\FetchingDataFailedEvent;
 use Unleash\Client\UnleashBuilder;
 use Unleash\Client\Event\UnleashEvents;
 
@@ -31,6 +32,7 @@ class MyEventSubscriber implements EventSubscriberInterface
             UnleashEvents::FEATURE_TOGGLE_DISABLED => 'onFeatureDisabled',
             UnleashEvents::FEATURE_TOGGLE_MISSING_STRATEGY_HANDLER => 'onNoStrategyHandler',
             UnleashEvents::FEATURE_TOGGLE_NOT_FOUND => 'onFeatureNotFound',
+            UnleashEvents::FETCHING_DATA_FAILED => 'onFetchingDataFailed',
         ];
     }
     
@@ -45,6 +47,11 @@ class MyEventSubscriber implements EventSubscriberInterface
     }
     
     public function onFeatureNotFound(FeatureToggleNotFoundEvent $event)
+    {
+        // todo
+    }
+    
+    public function onFetchingDataFailed(FetchingDataFailedEvent $event)
     {
         // todo
     }
@@ -70,6 +77,8 @@ The relevant methods will be called in the above example when their respective e
   Event object: Unleash\Client\Event\FeatureToggleDisabledEvent
 - `\Unleash\Client\Event\UnleashEvents::FEATURE_TOGGLE_MISSING_STRATEGY_HANDLER` - when there is no suitable strategy handler
   implemented for any of the feature's strategies. Event object: `Unleash\Client\Event\FeatureToggleMissingStrategyHandlerEvent`
+- `\Unleash\Client\Event\UnleashEvents::FETCHING_DATA_FAILED` - when http communication with the Unleash server fails
+  when fetching features. Event object: `Unleash\Client\Event\FetchingDataFailedEvent`
 
 ## FEATURE_TOGGLE_NOT_FOUND event
 
@@ -168,6 +177,37 @@ final class MyEventSubscriber implements EventSubscriberInterface
         $event->getFeature(); // instance of Feature
         // get strategies
         $event->getFeature()->getStrategies(); // iterable of Strategy instances
+    }
+}
+```
+
+## FETCHING_DATA_FAILED event
+
+Triggered when http communication with the Unleash server fails when fetching features.
+
+Example:
+
+```php
+<?php
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Unleash\Client\Event\UnleashEvents;
+use Unleash\Client\UnleashBuilder;
+use Unleash\Client\Event\FetchingDataFailedEvent;
+use Unleash\Client\Strategy\DefaultStrategyHandler;
+
+final class MyEventSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            UnleashEvents::FETCHING_DATA_FAILED => 'onFetchingDataFailed',
+        ];
+    }
+    
+    public function onFetchingDataFailed(FetchingDataFailedEvent $event): void
+    {
+        $event->getException(); // returns the exception that caused the failure
     }
 }
 ```

--- a/src/Configuration/UnleashConfiguration.php
+++ b/src/Configuration/UnleashConfiguration.php
@@ -41,6 +41,7 @@ final class UnleashConfiguration
         private bool $fetchingEnabled = true,
         // todo remove nullability in next major version
         private ?EventDispatcher $eventDispatcher = null,
+        private int $staleTtl = 30 * 60,
     ) {
         $this->contextProvider ??= new DefaultUnleashContextProvider();
         $this->eventDispatcher ??= new EventDispatcher(null);
@@ -259,6 +260,18 @@ final class UnleashConfiguration
     {
         $eventDispatcher ??= new EventDispatcher(null);
         $this->eventDispatcher = $eventDispatcher;
+
+        return $this;
+    }
+
+    public function getStaleTtl(): int
+    {
+        return $this->staleTtl;
+    }
+
+    public function setStaleTtl(int $staleTtl): self
+    {
+        $this->staleTtl = $staleTtl;
 
         return $this;
     }

--- a/src/Enum/CacheKey.php
+++ b/src/Enum/CacheKey.php
@@ -12,4 +12,6 @@ final class CacheKey
     public const FEATURES = 'unleash.client.feature.list';
 
     public const REGISTRATION = 'unleash.client.metrics.registration';
+
+    public const FEATURES_RESPONSE = 'unleash.client.feature.response';
 }

--- a/src/Event/AbstractEvent.php
+++ b/src/Event/AbstractEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Unleash\Client\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+// @codeCoverageIgnoreStart
+if (!class_exists(Event::class)) {
+    require __DIR__ . '/../../stubs/event-dispatcher/Event.php';
+}
+// @codeCoverageIgnoreEnd
+
+abstract class AbstractEvent extends Event
+{
+}

--- a/src/Event/FetchingDataFailedEvent.php
+++ b/src/Event/FetchingDataFailedEvent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Unleash\Client\Event;
+
+use Exception;
+
+final class FetchingDataFailedEvent extends AbstractEvent
+{
+    public function __construct(
+        private readonly Exception $exception,
+    ) {
+    }
+
+    public function getException(): Exception
+    {
+        return $this->exception;
+    }
+}

--- a/src/Event/UnleashEvents.php
+++ b/src/Event/UnleashEvents.php
@@ -24,4 +24,11 @@ final class UnleashEvents
      * @Event("Unleash\Client\Event\FeatureToggleMissingStrategyHandlerEvent")
      */
     public const FEATURE_TOGGLE_MISSING_STRATEGY_HANDLER = 'unleash.event.toggle.missing_strategy_handler';
+
+    /**
+     * Triggered when fetching features from server fails.
+     *
+     * @Event("Unleash\Client\Event\FetchingDataFailedEvent")
+     */
+    public const FETCHING_DATA_FAILED = 'unleash.event.server.fetching_failed';
 }

--- a/src/Repository/DefaultUnleashRepository.php
+++ b/src/Repository/DefaultUnleashRepository.php
@@ -74,6 +74,7 @@ final class DefaultUnleashRepository implements UnleashRepository
                     $response = $this->httpClient->sendRequest($request);
                     if ($response->getStatusCode() === 200) {
                         $data = $response->getBody()->getContents();
+                        $this->setLastValidState($data);
                     }
                 } catch (Exception $exception) {
                     $this->configuration->getEventDispatcher()->dispatch(
@@ -89,7 +90,6 @@ final class DefaultUnleashRepository implements UnleashRepository
                         isset($response) ? $response->getStatusCode() : 'unknown response status code'
                     ), 0, $exception ?? null);
                 }
-                $this->setLastValidState($data);
             }
 
             $features = $this->parseFeatures($data);

--- a/src/UnleashBuilder.php
+++ b/src/UnleashBuilder.php
@@ -65,6 +65,8 @@ final class UnleashBuilder
 
     private ?int $cacheTtl = null;
 
+    private ?int $staleTtl = null;
+
     private ?RegistrationService $registrationService = null;
 
     private bool $autoregister = true;
@@ -320,6 +322,12 @@ final class UnleashBuilder
         return $this->with('eventSubscribers', $subscribers);
     }
 
+    #[Pure]
+    public function withStaleTtl(?int $ttl): self
+    {
+        return $this->with('staleTtl', $ttl);
+    }
+
     public function build(): Unleash
     {
         $appUrl = $this->appUrl;
@@ -377,6 +385,7 @@ final class UnleashBuilder
         $configuration
             ->setCache($cache)
             ->setTtl($this->cacheTtl ?? $configuration->getTtl())
+            ->setStaleTtl($this->staleTtl ?? $configuration->getStaleTtl())
             ->setMetricsEnabled($this->metricsEnabled ?? $configuration->isMetricsEnabled())
             ->setMetricsInterval($this->metricsInterval ?? $configuration->getMetricsInterval())
             ->setHeaders($this->headers)

--- a/tests/Repository/DefaultUnleashRepositoryTest.php
+++ b/tests/Repository/DefaultUnleashRepositoryTest.php
@@ -270,4 +270,31 @@ final class DefaultUnleashRepositoryTest extends AbstractHttpClientTest
         $this->expectException(HttpResponseException::class);
         $repository->getFeatures();
     }
+
+    /**
+     * Tests that the cache doesn't get refreshed on its own
+     */
+    public function testFallbackStaleCacheNotRefreshing()
+    {
+        $repository = new DefaultUnleashRepository(
+            new Client([
+                'handler' => $this->handlerStack,
+            ]),
+            new HttpFactory(),
+            (new UnleashConfiguration('', '', ''))
+                ->setCache($this->getRealCache())
+                ->setTtl(0)
+                ->setStaleTtl(5)
+        );
+
+        $this->pushResponse($this->response);
+
+        $repository->getFeatures();
+
+        $this->expectException(HttpResponseException::class);
+        for ($i = 0; $i <= 5; ++$i) { // one more iteration than is the ttl
+            $repository->getFeatures();
+            sleep(1);
+        }
+    }
 }

--- a/tests/UnleashBuilderTest.php
+++ b/tests/UnleashBuilderTest.php
@@ -720,6 +720,23 @@ final class UnleashBuilderTest extends TestCase
         self::assertCount(1, $eventDispatcher->getListeners(UnleashEvents::FEATURE_TOGGLE_DISABLED));
     }
 
+    public function testWithStaleTtl()
+    {
+        $instance = $this->instance->withFetchingEnabled(false);
+        self::assertNull($this->getProperty($this->instance, 'staleTtl'));
+        self::assertEquals(
+            30 * 60,
+            $this->getConfiguration($instance->build())->getStaleTtl(),
+        );
+
+        $instance = $this->instance->withFetchingEnabled(false)->withStaleTtl(60 * 60);
+        self::assertNull($this->getProperty($this->instance, 'staleTtl'));
+        self::assertEquals(
+            60 * 60,
+            $this->getConfiguration($instance->build())->getStaleTtl(),
+        );
+    }
+
     private function getConfiguration(DefaultUnleash $unleash): UnleashConfiguration
     {
         $configurationProperty = (new ReflectionObject($unleash))->getProperty('configuration');


### PR DESCRIPTION
# Description

Adds configuration for stale data cache triggered in case of http communication failure.

Ref https://github.com/Unleash/unleash-client-symfony/issues/23 (this is part one, the other part must be done in Symfony bundle after this gets merged).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Integration tests / Manual Tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
