### PR TITLE
Enhancement: Make all events extend one parent

### DIFF
--- a/src/Event/FeatureToggleDisabledEvent.php
+++ b/src/Event/FeatureToggleDisabledEvent.php
@@ -2,15 +2,10 @@
 
 namespace Unleash\Client\Event;
 
-use Symfony\Contracts\EventDispatcher\Event;
 use Unleash\Client\Configuration\Context;
 use Unleash\Client\DTO\Feature;
 
-if (!class_exists(Event::class)) {
-    require __DIR__ . '/../../stubs/event-dispatcher/Event.php';
-}
-
-final class FeatureToggleDisabledEvent extends Event
+final class FeatureToggleDisabledEvent extends AbstractEvent
 {
     /**
      * @internal

--- a/src/Event/FeatureToggleMissingStrategyHandlerEvent.php
+++ b/src/Event/FeatureToggleMissingStrategyHandlerEvent.php
@@ -2,15 +2,10 @@
 
 namespace Unleash\Client\Event;
 
-use Symfony\Contracts\EventDispatcher\Event;
 use Unleash\Client\Configuration\Context;
 use Unleash\Client\DTO\Feature;
 
-if (!class_exists(Event::class)) {
-    require __DIR__ . '/../../stubs/event-dispatcher/Event.php';
-}
-
-final class FeatureToggleMissingStrategyHandlerEvent extends Event
+final class FeatureToggleMissingStrategyHandlerEvent extends AbstractEvent
 {
     /**
      * @internal

--- a/src/Event/FeatureToggleNotFoundEvent.php
+++ b/src/Event/FeatureToggleNotFoundEvent.php
@@ -2,12 +2,7 @@
 
 namespace Unleash\Client\Event;
 
-use Symfony\Contracts\EventDispatcher\Event;
 use Unleash\Client\Configuration\Context;
-
-if (!class_exists(Event::class)) {
-    require __DIR__ . '/../../stubs/event-dispatcher/Event.php';
-}
 
 final class FeatureToggleNotFoundEvent extends AbstractEvent
 {

--- a/src/Event/FeatureToggleNotFoundEvent.php
+++ b/src/Event/FeatureToggleNotFoundEvent.php
@@ -9,7 +9,7 @@ if (!class_exists(Event::class)) {
     require __DIR__ . '/../../stubs/event-dispatcher/Event.php';
 }
 
-final class FeatureToggleNotFoundEvent extends Event
+final class FeatureToggleNotFoundEvent extends AbstractEvent
 {
     /**
      * @internal


### PR DESCRIPTION
# Description

Makes all parents extend one parent (AbstractEvent)

Fixes #96 

## Type of change

Please delete options that are not relevant.

- [x] Enhancement

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
