### PR TITLE
Fix: Cache working for empty features

### DIFF
--- a/src/Repository/DefaultUnleashRepository.php
+++ b/src/Repository/DefaultUnleashRepository.php
@@ -55,7 +55,8 @@ final class DefaultUnleashRepository implements UnleashRepository
      */
     public function getFeatures(): iterable
     {
-        if (!$features = $this->getCachedFeatures()) {
+        $features = $this->getCachedFeatures();
+        if ($features === null) {
             if (!$this->configuration->isFetchingEnabled()) {
                 if (!$data = $this->getBootstrappedResponse()) {
                     throw new LogicException('Fetching of Unleash api is disabled but no bootstrap is provided');

--- a/tests/Repository/DefaultUnleashRepositoryTest.php
+++ b/tests/Repository/DefaultUnleashRepositoryTest.php
@@ -112,6 +112,35 @@ final class DefaultUnleashRepositoryTest extends AbstractHttpClientTest
         self::assertEquals($feature->getName(), $repository->findFeature('test')->getName());
     }
 
+    public function testCacheWithNoFeatures()
+    {
+        $response = [
+            'version' => 1,
+            'features' => [],
+        ];
+
+        $cache = $this->getRealCache();
+
+        $repository = new DefaultUnleashRepository(
+            new Client([
+                'handler' => $this->handlerStack,
+            ]),
+            new HttpFactory(),
+            (new UnleashConfiguration('', '', ''))
+                ->setCache($cache)
+                ->setTtl(5)
+        );
+
+        $this->pushResponse($response, 2);
+        $repository->getFeatures();
+        $repository->getFeatures();
+        self::assertEquals(1, $this->mockHandler->count());
+        $cache->clear();
+
+        $this->pushResponse($response);
+        self::assertNull($repository->findFeature('test'));
+    }
+
     public function testCustomHeaders()
     {
         $this->pushResponse($this->response);


### PR DESCRIPTION
# Description

PHP evaluates to false for empty arrays, this fix explicitly checks for null instead of implicitly casting the result to bool.

Fixes #105 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Integration tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
