### PR TITLE
Fix: Don't throw on older version of event dispatcher

### DIFF
--- a/src/Configuration/UnleashConfiguration.php
+++ b/src/Configuration/UnleashConfiguration.php
@@ -6,6 +6,7 @@ use JetBrains\PhpStorm\Deprecated;
 use JetBrains\PhpStorm\Pure;
 use LogicException;
 use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Unleash\Client\Bootstrap\BootstrapHandler;
 use Unleash\Client\Bootstrap\BootstrapProvider;
 use Unleash\Client\Bootstrap\DefaultBootstrapHandler;
@@ -40,11 +41,10 @@ final class UnleashConfiguration
         private ?BootstrapProvider $bootstrapProvider = null,
         private bool $fetchingEnabled = true,
         // todo remove nullability in next major version
-        private ?EventDispatcher $eventDispatcher = null,
+        private ?EventDispatcherInterface $eventDispatcher = null,
         private int $staleTtl = 30 * 60,
     ) {
         $this->contextProvider ??= new DefaultUnleashContextProvider();
-        $this->eventDispatcher ??= new EventDispatcher(null);
         if ($defaultContext !== null) {
             $this->setDefaultContext($defaultContext);
         }
@@ -245,14 +245,29 @@ final class UnleashConfiguration
         return $this;
     }
 
+    #[Deprecated('This method has been deprecated and will be removed in next major version')]
     public function getEventDispatcher(): EventDispatcher
     {
-        return $this->eventDispatcher ?? new EventDispatcher(null);
+        if ($this->eventDispatcher === null) {
+            return new EventDispatcher(null);
+        }
+        if ($this->eventDispatcher instanceof EventDispatcher) {
+            return $this->eventDispatcher;
+        }
+
+        return new EventDispatcher($this->eventDispatcher);
     }
 
-    public function setEventDispatcher(?EventDispatcher $eventDispatcher): self
+    /**
+     * @internal
+     */
+    public function getEventDispatcherOrNull(): ?EventDispatcherInterface
     {
-        $eventDispatcher ??= new EventDispatcher(null);
+        return $this->eventDispatcher;
+    }
+
+    public function setEventDispatcher(?EventDispatcherInterface $eventDispatcher): self
+    {
         $this->eventDispatcher = $eventDispatcher;
 
         return $this;

--- a/src/ConstraintValidator/DefaultConstraintValidator.php
+++ b/src/ConstraintValidator/DefaultConstraintValidator.php
@@ -64,6 +64,7 @@ final class DefaultConstraintValidator implements ConstraintValidator
      * @param T $value
      *
      * @return T
+     *
      * @noinspection PhpDocSignatureInspection
      */
     private function makeCaseInsensitive(string|array $value): string|array

--- a/src/DTO/VariantPayload.php
+++ b/src/DTO/VariantPayload.php
@@ -18,6 +18,7 @@ interface VariantPayload extends JsonSerializable
      * @throws LogicException
      *
      * @return array<mixed>
+     *
      * @noinspection PhpPluralMixedCanBeReplacedWithArrayInspection
      */
     public function fromJson(): array;

--- a/src/DefaultUnleash.php
+++ b/src/DefaultUnleash.php
@@ -44,7 +44,7 @@ final class DefaultUnleash implements Unleash
         $feature = $this->repository->findFeature($featureName);
         if ($feature === null) {
             $event = new FeatureToggleNotFoundEvent($context, $featureName);
-            $this->configuration->getEventDispatcher()->dispatch(
+            $this->configuration->getEventDispatcherOrNull()?->dispatch(
                 $event,
                 UnleashEvents::FEATURE_TOGGLE_NOT_FOUND,
             );
@@ -61,12 +61,12 @@ final class DefaultUnleash implements Unleash
                 clone $feature,
                 null,
             );
-            $this->configuration->getEventDispatcher()->dispatch($event, UnleashEvents::IMPRESSION_DATA);
+            $this->configuration->getEventDispatcherOrNull()?->dispatch($event, UnleashEvents::IMPRESSION_DATA);
         }
 
         if (!$feature->isEnabled()) {
             $event = new FeatureToggleDisabledEvent($feature, $context);
-            $this->configuration->getEventDispatcher()->dispatch(
+            $this->configuration->getEventDispatcherOrNull()?->dispatch(
                 $event,
                 UnleashEvents::FEATURE_TOGGLE_DISABLED,
             );
@@ -104,7 +104,7 @@ final class DefaultUnleash implements Unleash
 
         if (!$handlersFound) {
             $event = new FeatureToggleMissingStrategyHandlerEvent($context, $feature);
-            $this->configuration->getEventDispatcher()->dispatch(
+            $this->configuration->getEventDispatcherOrNull()?->dispatch(
                 $event,
                 UnleashEvents::FEATURE_TOGGLE_MISSING_STRATEGY_HANDLER,
             );
@@ -138,7 +138,7 @@ final class DefaultUnleash implements Unleash
                     clone $feature,
                     clone $variant,
                 );
-                $this->configuration->getEventDispatcher()->dispatch($event, UnleashEvents::IMPRESSION_DATA);
+                $this->configuration->getEventDispatcherOrNull()?->dispatch($event, UnleashEvents::IMPRESSION_DATA);
             }
         }
 

--- a/src/Helper/EventDispatcher.php
+++ b/src/Helper/EventDispatcher.php
@@ -2,6 +2,7 @@
 
 namespace Unleash\Client\Helper;
 
+use JetBrains\PhpStorm\Deprecated;
 use JetBrains\PhpStorm\ExpectedValues;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -13,6 +14,7 @@ if (!interface_exists(EventDispatcherInterface::class)) {
 }
 // @codeCoverageIgnoreEnd
 
+#[Deprecated('This class was deprecated and will be removed in next major version')]
 /**
  * @internal
  */

--- a/src/Repository/DefaultUnleashRepository.php
+++ b/src/Repository/DefaultUnleashRepository.php
@@ -93,7 +93,7 @@ final class DefaultUnleashRepository implements UnleashRepository
                         $this->setLastValidState($data);
                     }
                 } catch (Exception $exception) {
-                    $this->configuration->getEventDispatcher()->dispatch(
+                    $this->configuration->getEventDispatcherOrNull()?->dispatch(
                         new FetchingDataFailedEvent($exception),
                         UnleashEvents::FETCHING_DATA_FAILED,
                     );

--- a/src/UnleashBuilder.php
+++ b/src/UnleashBuilder.php
@@ -30,7 +30,6 @@ use Unleash\Client\ContextProvider\SettableUnleashContextProvider;
 use Unleash\Client\ContextProvider\UnleashContextProvider;
 use Unleash\Client\Exception\InvalidValueException;
 use Unleash\Client\Helper\DefaultImplementationLocator;
-use Unleash\Client\Helper\EventDispatcher;
 use Unleash\Client\Metrics\DefaultMetricsHandler;
 use Unleash\Client\Metrics\DefaultMetricsSender;
 use Unleash\Client\Repository\DefaultUnleashRepository;
@@ -97,6 +96,7 @@ final class UnleashBuilder
 
     /**
      * @var EventDispatcherInterface|null
+     *
      * @noinspection PhpDocFieldTypeMismatchInspection
      */
     private ?object $eventDispatcher = null;
@@ -376,9 +376,9 @@ final class UnleashBuilder
 
         $bootstrapHandler = $this->bootstrapHandler ?? new DefaultBootstrapHandler();
         $bootstrapProvider = $this->bootstrapProvider ?? new EmptyBootstrapProvider();
-        $eventDispatcher = new EventDispatcher($this->eventDispatcher);
+        $eventDispatcher = $this->eventDispatcher;
         foreach ($this->eventSubscribers as $eventSubscriber) {
-            $eventDispatcher->addSubscriber($eventSubscriber);
+            $eventDispatcher?->addSubscriber($eventSubscriber);
         }
 
         $configuration = new UnleashConfiguration($appUrl, $appName, $instanceId);

--- a/tests/CoverageOnlyTest.php
+++ b/tests/CoverageOnlyTest.php
@@ -3,6 +3,7 @@
 namespace Unleash\Client\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Unleash\Client\Configuration\UnleashConfiguration;
 use Unleash\Client\Configuration\UnleashContext;
 use Unleash\Client\DTO\DefaultFeature;
@@ -14,6 +15,7 @@ use Unleash\Client\Event\FeatureToggleDisabledEvent;
 use Unleash\Client\Event\FeatureToggleMissingStrategyHandlerEvent;
 use Unleash\Client\Event\FeatureToggleNotFoundEvent;
 use Unleash\Client\Exception\CompoundException;
+use Unleash\Client\Helper\EventDispatcher as HelperEventDispatcher;
 
 /**
  * This class is only for triggering code that doesn't really make sense to test and is here to achieve 100% code coverage.
@@ -97,5 +99,19 @@ final class CoverageOnlyTest extends TestCase
         $instance = new CompoundException();
 
         $instance->getExceptions();
+    }
+
+    public function testGetEventDispatcher()
+    {
+        $configuration = fn () => new UnleashConfiguration('', '', '', fetchingEnabled: false);
+
+        $configurationNull = $configuration()->setEventDispatcher(null);
+        $configurationNull->getEventDispatcher();
+
+        $configurationHelper = $configuration()->setEventDispatcher(new HelperEventDispatcher(null));
+        $configurationHelper->getEventDispatcher();
+
+        $configurationEventDispatcher = $configuration()->setEventDispatcher(new EventDispatcher());
+        $configurationEventDispatcher->getEventDispatcher();
     }
 }

--- a/tests/UnleashBuilderTest.php
+++ b/tests/UnleashBuilderTest.php
@@ -32,7 +32,6 @@ use Unleash\Client\Event\FeatureToggleDisabledEvent;
 use Unleash\Client\Event\FeatureToggleNotFoundEvent;
 use Unleash\Client\Event\UnleashEvents;
 use Unleash\Client\Exception\InvalidValueException;
-use Unleash\Client\Helper\EventDispatcher;
 use Unleash\Client\Strategy\DefaultStrategyHandler;
 use Unleash\Client\Strategy\StrategyHandler;
 use Unleash\Client\Tests\TestHelpers\CustomBootstrapProviderImpl74;
@@ -646,26 +645,16 @@ final class UnleashBuilderTest extends TestCase
         self::assertSame($eventDispatcher, $property);
 
         $unleash = $instance->withFetchingEnabled(false)->build();
-        $configuredEventDispatcher = $this->getConfiguration($unleash)->getEventDispatcher();
-        self::assertInstanceOf(EventDispatcher::class, $configuredEventDispatcher);
-
-        $innerEventDispatcher = $this->getProperty($configuredEventDispatcher, 'eventDispatcher');
-        self::assertInstanceOf(SymfonyEventDispatcher::class, $innerEventDispatcher);
-        self::assertSame($eventDispatcher, $innerEventDispatcher);
+        $configuredEventDispatcher = $this->getConfiguration($unleash)->getEventDispatcherOrNull();
+        self::assertInstanceOf(SymfonyEventDispatcher::class, $configuredEventDispatcher);
 
         $unleash = $this->instance->withFetchingEnabled(false)->build();
-        $configuredEventDispatcher = $this->getConfiguration($unleash)->getEventDispatcher();
-        self::assertInstanceOf(EventDispatcher::class, $configuredEventDispatcher);
-
-        $innerEventDispatcher = $this->getProperty($configuredEventDispatcher, 'eventDispatcher');
-        self::assertInstanceOf(SymfonyEventDispatcher::class, $innerEventDispatcher);
+        $configuredEventDispatcher = $this->getConfiguration($unleash)->getEventDispatcherOrNull();
+        self::assertInstanceOf(SymfonyEventDispatcher::class, $configuredEventDispatcher);
 
         $unleash = $this->instance->withFetchingEnabled(false)->withEventDispatcher(null)->build();
-        $configuredEventDispatcher = $this->getConfiguration($unleash)->getEventDispatcher();
-        self::assertInstanceOf(EventDispatcher::class, $configuredEventDispatcher);
-
-        $innerEventDispatcher = $this->getProperty($configuredEventDispatcher, 'eventDispatcher');
-        self::assertNull($innerEventDispatcher);
+        $configuredEventDispatcher = $this->getConfiguration($unleash)->getEventDispatcherOrNull();
+        self::assertNull($configuredEventDispatcher);
     }
 
     public function testWithEventSubscriber()
@@ -710,10 +699,7 @@ final class UnleashBuilderTest extends TestCase
         ));
 
         $unleash = $instance->build();
-        $eventDispatcher = $this->getProperty(
-            $this->getConfiguration($unleash)->getEventDispatcher(),
-            'eventDispatcher'
-        );
+        $eventDispatcher = $this->getConfiguration($unleash)->getEventDispatcherOrNull();
         self::assertInstanceOf(SymfonyEventDispatcher::class, $eventDispatcher);
         self::assertCount(2, $eventDispatcher->getListeners());
         self::assertCount(1, $eventDispatcher->getListeners(UnleashEvents::FEATURE_TOGGLE_NOT_FOUND));


### PR DESCRIPTION
# Description

Makes it possible to use older versions of symfony event dispatcher and more importantly doesn't throw an uncatchable error when it's present. Tested with version ^4.0.

Fixes #112 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Manual Tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
