### PR TITLE
Allow psr/simple-cache 3.x

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,6 +49,8 @@ jobs:
     strategy:
       matrix:
         version: ['8.1']
+        optional-deps: ['', 'cache/filesystem-adapter:^1.1']
+
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -58,7 +60,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Install Dependencies
+      - name: Install Dependencies (without optional)
+        if: ${{ matrix.optional-deps == '' }}
         run: composer install
+      - name: Install Dependencies (with optional)
+        if: ${{ matrix.optional-deps != '' }}
+        run: composer require ${{ matrix.optional-deps }}
       - name: Run tests
         run: composer phpunit

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-factory-implementation": "^1.0",
-        "psr/simple-cache": "^1.0",
-        "psr/simple-cache-implementation": "^1.0",
+        "psr/simple-cache": "^1.0 | ^2.0 | ^3.0",
+        "psr/simple-cache-implementation": "^1.0 | ^2.0 | ^3.0",
         "lastguest/murmurhash": "^2.1",
         "psr/http-message": "^1.0",
         "php-http/discovery": "^1.14"

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.0",
-        "cache/filesystem-adapter": "^1.1",
         "friendsofphp/php-cs-fixer": "^3.0",
         "phpstan/phpstan": "^1.2",
         "jetbrains/phpstorm-attributes": "^1.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,13 @@
 parameters:
   ignoreErrors:
-    - '#@throws with type .+ is not subtype of Throwable#'
+    -
+      message: '#@throws with type .+SimpleCache.+ is not subtype of Throwable#'
+      path: src/Repository/DefaultUnleashRepository.php
+      reportUnmatched: false
+    -
+      messages:
+        - '#Class .+Filesystem.* not found#'
+        - '#Class .+Flysystem.* not found#'
+      path: src/Helper/DefaultImplementationLocator.php
+      reportUnmatched: false
   treatPhpDocTypesAsCertain: false

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,8 +1,7 @@
 parameters:
   ignoreErrors:
     -
-      message: '#@throws with type .+SimpleCache.+ is not subtype of Throwable#'
-      path: src/Repository/DefaultUnleashRepository.php
+      message: '#@throws with type .+ is not subtype of Throwable#'
       reportUnmatched: false
     -
       messages:

--- a/tests/Traits/FakeCacheImplementationTrait.php
+++ b/tests/Traits/FakeCacheImplementationTrait.php
@@ -3,51 +3,13 @@
 namespace Unleash\Client\Tests\Traits;
 
 use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Cache\Psr16Cache;
 
 trait FakeCacheImplementationTrait
 {
     private function getCache(): CacheInterface
     {
-        return new class implements CacheInterface {
-            public function get($key, $default = null)
-            {
-                return $default;
-            }
-
-            public function set($key, $value, $ttl = null): bool
-            {
-                return true;
-            }
-
-            public function delete($key): bool
-            {
-                return true;
-            }
-
-            public function clear(): bool
-            {
-                return true;
-            }
-
-            public function getMultiple($keys, $default = null)
-            {
-                return $default;
-            }
-
-            public function setMultiple($values, $ttl = null): bool
-            {
-                return true;
-            }
-
-            public function deleteMultiple($keys): bool
-            {
-                return true;
-            }
-
-            public function has($key): bool
-            {
-                return false;
-            }
-        };
+        return new Psr16Cache(new NullAdapter());
     }
 }

--- a/tests/Traits/RealCacheImplementationTrait.php
+++ b/tests/Traits/RealCacheImplementationTrait.php
@@ -2,10 +2,9 @@
 
 namespace Unleash\Client\Tests\Traits;
 
-use Cache\Adapter\Filesystem\FilesystemCachePool;
-use League\Flysystem\Adapter\Local;
-use League\Flysystem\Filesystem;
 use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Psr16Cache;
 
 trait RealCacheImplementationTrait
 {
@@ -24,11 +23,7 @@ trait RealCacheImplementationTrait
     private function getCache(): CacheInterface
     {
         if ($this->_cache === null) {
-            $this->_cache = new FilesystemCachePool(
-                new Filesystem(
-                    new Local(sys_get_temp_dir() . '/unleash-sdk-tests')
-                )
-            );
+            $this->_cache = new Psr16Cache(new ArrayAdapter());
         }
 
         return $this->_cache;


### PR DESCRIPTION
# Description

Adds support for using this library with `psr/simple-cache` 2.x and 3.x without breaking backward-compatibility.

Closes #119

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Spec Tests
- [ ] Integration tests / Manual Tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
