### PR TITLE
Read the response body from the start

### DIFF
--- a/src/Repository/DefaultUnleashRepository.php
+++ b/src/Repository/DefaultUnleashRepository.php
@@ -89,7 +89,7 @@ final class DefaultUnleashRepository implements UnleashRepository
                 try {
                     $response = $this->httpClient->sendRequest($request);
                     if ($response->getStatusCode() === 200) {
-                        $data = $response->getBody()->getContents();
+                        $data = (string) $response->getBody();
                         $this->setLastValidState($data);
                     }
                 } catch (Exception $exception) {


### PR DESCRIPTION
# Description

Fixes #122 by using `__toString()` to read the response body [which always attempts to read the stream from the start](https://github.com/php-fig/http-message/blob/efd67d1dc14a7ef4fc4e518e7dee91c271d524e4/src/StreamInterface.php#L14-L28). 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [ ] Spec Tests
- [ ] Integration tests / Manual Tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
