### PR TITLE
Fix: Load stale data whenever there's any http error

### DIFF
--- a/src/Repository/DefaultUnleashRepository.php
+++ b/src/Repository/DefaultUnleashRepository.php
@@ -91,6 +91,8 @@ final class DefaultUnleashRepository implements UnleashRepository
                     if ($response->getStatusCode() === 200) {
                         $data = (string) $response->getBody();
                         $this->setLastValidState($data);
+                    } else {
+                        throw new HttpResponseException("Invalid status code: '{$response->getStatusCode()}'");
                     }
                 } catch (Exception $exception) {
                     $this->configuration->getEventDispatcherOrNull()?->dispatch(


### PR DESCRIPTION
# Description

Fixes incorrect behavior when stale fallback data weren't returned when non-200 status code was returned.

Fixes #129 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Integration tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
