### PR TITLE
Fix/ends with operator

### DIFF
--- a/src/ConstraintValidator/Operator/String/StringEndsWithOperatorValidator.php
+++ b/src/ConstraintValidator/Operator/String/StringEndsWithOperatorValidator.php
@@ -11,6 +11,6 @@ final class StringEndsWithOperatorValidator extends AbstractStringOperatorValida
     {
         assert(is_string($searchInValue));
 
-        return str_ends_with($searchInValue, $currentValue);
+        return str_ends_with($currentValue, $searchInValue);
     }
 }

--- a/tests/Strategy/GradualRolloutStrategyHandlerTest.php
+++ b/tests/Strategy/GradualRolloutStrategyHandlerTest.php
@@ -144,6 +144,24 @@ final class GradualRolloutStrategyHandlerTest extends TestCase
             $strategy,
             (new UnleashContext())->setCustomProperty('something', 'test')
         ));
+
+        // using stickiness=default
+        $strategy = $this->createStrategy(100, Stickiness::DEFAULT, [
+            new DefaultConstraint('email', ConstraintOperator::STRING_ENDS_WITH, ['test.com']),
+        ]);
+        self::assertTrue($this->instance->isEnabled(
+            $strategy,
+            (new UnleashContext())->setCustomProperty('email', 'me@test.com')
+        ));
+
+        // using stickiness=email
+        $strategy = $this->createStrategy(100, 'email', [
+            new DefaultConstraint('email', ConstraintOperator::STRING_ENDS_WITH, ['test.com']),
+        ]);
+        self::assertTrue($this->instance->isEnabled(
+            $strategy,
+            (new UnleashContext())->setCustomProperty('email', 'me@test.com')
+        ));
     }
 
     #[Pure]


### PR DESCRIPTION
This patches the strEndsWith operator to check that constraint property ends with the context property rather than the reverse. The reason the client specifications were passing is because of a bug in that project (patched here: https://github.com/Unleash/client-specification/pull/47).

strStartsWith is not affected, the check is correct here: https://github.com/Unleash/unleash-client-php/blob/main/src/ConstraintValidator/Operator/String/StringStartsWithOperatorValidator.php

We might want to think about what version we release this under. Technically it's a bug fix but there's a risk of having an automated bot upgrade the SDK because it sees a patch version and flipping a bunch of toggles in the wild. 