### PR TITLE
Chore: Ignore rector configuration file in dist packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,4 @@
 /rector.73.php export-ignore
 /rector.74.php export-ignore
 /rector.80.php export-ignore
+/rector.81.php export-ignore


### PR DESCRIPTION
# Description

Ignores rector configuration file in dist packages as it's not needed if installed as a dependency.