### PR TITLE
Fix: Skip test that doesn't work on Windows if running on Windows

### DIFF
--- a/tests/Bootstrap/FileBootstrapProviderTest.php
+++ b/tests/Bootstrap/FileBootstrapProviderTest.php
@@ -69,6 +69,9 @@ final class FileBootstrapProviderTest extends TestCase
 
     public function testUnreadableFile()
     {
+        if (strtolower(substr(PHP_OS, 0, 3)) === 'win') {
+            self::markTestSkipped("This test doesn't run correctly on Windows");
+        }
         $file = $this->createTemporaryFile();
         chmod($file, 0222);
         $instance = new FileBootstrapProvider($file);


### PR DESCRIPTION
# Description

The test doesn't work on Windows because chmod permissions are not available.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
