### PR TITLE
Fix: Catch an exception when a http failure occurs

### DIFF
--- a/src/Metrics/DefaultMetricsSender.php
+++ b/src/Metrics/DefaultMetricsSender.php
@@ -2,6 +2,7 @@
 
 namespace Unleash\Client\Metrics;
 
+use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Unleash\Client\Configuration\UnleashConfiguration;
@@ -33,6 +34,11 @@ final class DefaultMetricsSender implements MetricsSender
         foreach ($this->configuration->getHeaders() as $name => $value) {
             $request = $request->withHeader($name, $value);
         }
-        $this->httpClient->sendRequest($request);
+
+        try {
+            $this->httpClient->sendRequest($request);
+        } catch (ClientExceptionInterface) {
+            // ignore the error
+        }
     }
 }

--- a/tests/Metrics/DefaultMetricsSenderTest.php
+++ b/tests/Metrics/DefaultMetricsSenderTest.php
@@ -3,6 +3,7 @@
 namespace Unleash\Client\Tests\Metrics;
 
 use DateTimeImmutable;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\HttpFactory;
 use Unleash\Client\Configuration\UnleashConfiguration;
 use Unleash\Client\DTO\DefaultFeature;
@@ -14,31 +15,37 @@ use Unleash\Client\Tests\AbstractHttpClientTest;
 
 final class DefaultMetricsSenderTest extends AbstractHttpClientTest
 {
+    private DefaultMetricsSender $instance;
+
+    private UnleashConfiguration $configuration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configuration = new UnleashConfiguration('', '', '');
+        $this->instance = new DefaultMetricsSender($this->httpClient, new HttpFactory(), $this->configuration);
+    }
+
     public function testSendMetrics()
     {
-        $configuration = new UnleashConfiguration('', '', '');
-        $configuration->setHeaders([
+        $this->configuration->setHeaders([
             'Authorization' => 'test',
         ]);
 
-        $instance = new DefaultMetricsSender(
-            $this->httpClient,
-            new HttpFactory(),
-            $configuration
-        );
         $bucket = new MetricsBucket(new DateTimeImmutable(), new DateTimeImmutable());
         $bucket
             ->addToggle(new MetricsBucketToggle(new DefaultFeature('test', true, []), true, null));
 
         $this->pushResponse([], 1, 202);
-        $instance->sendMetrics($bucket);
+        $this->instance->sendMetrics($bucket);
         $this->pushResponse([], 1, 401);
-        $instance->sendMetrics($bucket);
-        $configuration->setMetricsEnabled(false);
-        $instance->sendMetrics($bucket);
+        $this->instance->sendMetrics($bucket);
+        $this->configuration->setMetricsEnabled(false);
+        $this->instance->sendMetrics($bucket);
         self::assertCount(2, $this->requestHistory);
 
-        $configuration->setMetricsEnabled(true);
+        $this->configuration->setMetricsEnabled(true);
         $bucket
             ->addToggle(new MetricsBucketToggle(
                 new DefaultFeature('tet', true, []),
@@ -46,6 +53,13 @@ final class DefaultMetricsSenderTest extends AbstractHttpClientTest
                 new DefaultVariant('test', true)
             ));
         $this->pushResponse([]);
-        $instance->sendMetrics($bucket);
+        $this->instance->sendMetrics($bucket);
+    }
+
+    public function testSendMetricsFailure()
+    {
+        $this->pushResponse(new TransferException());
+        $bucket = new MetricsBucket(new DateTimeImmutable(), new DateTimeImmutable());
+        $this->instance->sendMetrics($bucket);
     }
 }

--- a/tests/Metrics/DefaultMetricsSenderTest.php
+++ b/tests/Metrics/DefaultMetricsSenderTest.php
@@ -15,9 +15,15 @@ use Unleash\Client\Tests\AbstractHttpClientTest;
 
 final class DefaultMetricsSenderTest extends AbstractHttpClientTest
 {
-    private DefaultMetricsSender $instance;
+    /**
+     * @var DefaultMetricsSender
+     */
+    private $instance;
 
-    private UnleashConfiguration $configuration;
+    /**
+     * @var UnleashConfiguration
+     */
+    private $configuration;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
# Description

Fixes an error reported on Slack where a http exception isn't caught.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
