### PR TITLE
fix: make proxy client respect cache ttl

### DIFF
--- a/src/Repository/DefaultUnleashProxyRepository.php
+++ b/src/Repository/DefaultUnleashProxyRepository.php
@@ -69,7 +69,7 @@ final class DefaultUnleashProxyRepository implements ProxyRepository
 
             if ($featureData !== null) {
                 if ($this->configuration->getCache() !== null) {
-                    $this->configuration->getCache()->set($cacheKey, $featureData);
+                    $this->configuration->getCache()->set($cacheKey, $featureData, $this->configuration->getTtl());
                 }
 
                 return new DefaultProxyFeature($featureData);


### PR DESCRIPTION
This allows the Proxy Client to respect the cache ttl set in the configuration, otherwise the cache items lives for as long as the cache feels like allowing it to live