### PR TITLE
fix: return disabled variant when feature evaluated false

### DIFF
--- a/src/DefaultUnleash.php
+++ b/src/DefaultUnleash.php
@@ -26,13 +26,14 @@ final class DefaultUnleash implements Unleash
      * @param iterable<StrategyHandler> $strategyHandlers
      */
     public function __construct(
-        private readonly iterable $strategyHandlers,
-        private readonly UnleashRepository $repository,
-        private readonly RegistrationService $registrationService,
+        private readonly iterable             $strategyHandlers,
+        private readonly UnleashRepository    $repository,
+        private readonly RegistrationService  $registrationService,
         private readonly UnleashConfiguration $configuration,
-        private readonly MetricsHandler $metricsHandler,
-        private readonly VariantHandler $variantHandler,
-    ) {
+        private readonly MetricsHandler       $metricsHandler,
+        private readonly VariantHandler       $variantHandler,
+    )
+    {
         if ($configuration->isAutoRegistrationEnabled()) {
             $this->register();
         }
@@ -43,7 +44,7 @@ final class DefaultUnleash implements Unleash
         $context ??= $this->configuration->getContextProvider()->getContext();
         $feature = $this->findFeature($featureName, $context);
 
-        if($feature !== null) {
+        if ($feature !== null) {
             if (method_exists($feature, 'hasImpressionData') && $feature->hasImpressionData()) {
                 $event = new ImpressionDataEvent(
                     ImpressionDataEventType::IS_ENABLED,
@@ -67,7 +68,7 @@ final class DefaultUnleash implements Unleash
 
         $feature = $this->findFeature($featureName, $context);
         $isEnabled = $this->isFeatureEnabled($feature, $context);
-        if ($feature === null || !$isEnabled || !count($feature->getVariants())) {
+        if ($feature === null || $isEnabled === FALSE || !count($feature->getVariants())) {
             return $fallbackVariant;
         }
 
@@ -97,6 +98,12 @@ final class DefaultUnleash implements Unleash
         return $this->registrationService->register($this->strategyHandlers);
     }
 
+    /**
+     * Finds a feature and posts events if the feature is not found.
+     * @param string $featureName
+     * @param Context $context
+     * @return Feature|null
+     */
     private function findFeature(string $featureName, Context $context): ?Feature
     {
         $feature = $this->repository->findFeature($featureName);
@@ -111,6 +118,13 @@ final class DefaultUnleash implements Unleash
         return $feature;
     }
 
+    /**
+     * Underlying method to check if a feature is enabled.
+     * @param Feature|null $feature
+     * @param Context $context
+     * @param bool $default
+     * @return bool
+     */
     private function isFeatureEnabled(?Feature $feature, Context $context, bool $default = false): bool
     {
         if ($feature === null) {

--- a/src/DefaultUnleash.php
+++ b/src/DefaultUnleash.php
@@ -26,14 +26,13 @@ final class DefaultUnleash implements Unleash
      * @param iterable<StrategyHandler> $strategyHandlers
      */
     public function __construct(
-        private readonly iterable             $strategyHandlers,
-        private readonly UnleashRepository    $repository,
-        private readonly RegistrationService  $registrationService,
+        private readonly iterable $strategyHandlers,
+        private readonly UnleashRepository $repository,
+        private readonly RegistrationService $registrationService,
         private readonly UnleashConfiguration $configuration,
-        private readonly MetricsHandler       $metricsHandler,
-        private readonly VariantHandler       $variantHandler,
-    )
-    {
+        private readonly MetricsHandler $metricsHandler,
+        private readonly VariantHandler $variantHandler,
+    ) {
         if ($configuration->isAutoRegistrationEnabled()) {
             $this->register();
         }
@@ -68,7 +67,7 @@ final class DefaultUnleash implements Unleash
 
         $feature = $this->findFeature($featureName, $context);
         $isEnabled = $this->isFeatureEnabled($feature, $context);
-        if ($feature === null || $isEnabled === FALSE || !count($feature->getVariants())) {
+        if ($feature === null || $isEnabled === false || !count($feature->getVariants())) {
             return $fallbackVariant;
         }
 
@@ -100,8 +99,10 @@ final class DefaultUnleash implements Unleash
 
     /**
      * Finds a feature and posts events if the feature is not found.
-     * @param string $featureName name of the feature to find
-     * @param Context $context the context to use
+     *
+     * @param string  $featureName name of the feature to find
+     * @param Context $context     the context to use
+     *
      * @return Feature|null
      */
     private function findFeature(string $featureName, Context $context): ?Feature
@@ -120,9 +121,11 @@ final class DefaultUnleash implements Unleash
 
     /**
      * Underlying method to check if a feature is enabled.
+     *
      * @param Feature|null $feature the feature to check
-     * @param Context $context the context to use
-     * @param bool $default the default value to return if the feature is not found
+     * @param Context      $context the context to use
+     * @param bool         $default the default value to return if the feature is not found
+     *
      * @return bool
      */
     private function isFeatureEnabled(?Feature $feature, Context $context, bool $default = false): bool

--- a/src/DefaultUnleash.php
+++ b/src/DefaultUnleash.php
@@ -57,7 +57,6 @@ final class DefaultUnleash implements Unleash
             }
         }
 
-
         return $this->isFeatureEnabled($feature, $context, $default);
     }
 
@@ -98,7 +97,7 @@ final class DefaultUnleash implements Unleash
         return $this->registrationService->register($this->strategyHandlers);
     }
 
-    private function findFeature(string $featureName, ?Context $context = null): ?Feature
+    private function findFeature(string $featureName, Context $context): ?Feature
     {
         $feature = $this->repository->findFeature($featureName);
         if ($feature === null) {
@@ -112,7 +111,7 @@ final class DefaultUnleash implements Unleash
         return $feature;
     }
 
-    private function isFeatureEnabled(?Feature $feature, ?Context $context = null, bool $default = false): bool
+    private function isFeatureEnabled(?Feature $feature, Context $context, bool $default = false): bool
     {
         if ($feature === null) {
             return $default;

--- a/src/DefaultUnleash.php
+++ b/src/DefaultUnleash.php
@@ -79,7 +79,7 @@ final class DefaultUnleash implements Unleash
     private function findFeature(string $featureName) : ?Feature {
         $feature = $this->repository->findFeature($featureName);
         if ($feature === null) {
-            $context ??= $this->configuration->getContextProvider()->getContext();
+            $context = $this->configuration->getContextProvider()->getContext();
             $event = new FeatureToggleNotFoundEvent($context, $featureName);
             $this->configuration->getEventDispatcherOrNull()?->dispatch(
                 $event,
@@ -91,7 +91,7 @@ final class DefaultUnleash implements Unleash
 
     private function isFeatureEnabled(?Feature $feature, bool $default = false): bool
     {
-        $context ??= $this->configuration->getContextProvider()->getContext();
+        $context = $this->configuration->getContextProvider()->getContext();
 
         if ($feature === null) {
             return $default;

--- a/src/DefaultUnleash.php
+++ b/src/DefaultUnleash.php
@@ -100,8 +100,8 @@ final class DefaultUnleash implements Unleash
 
     /**
      * Finds a feature and posts events if the feature is not found.
-     * @param string $featureName
-     * @param Context $context
+     * @param string $featureName name of the feature to find
+     * @param Context $context the context to use
      * @return Feature|null
      */
     private function findFeature(string $featureName, Context $context): ?Feature
@@ -120,9 +120,9 @@ final class DefaultUnleash implements Unleash
 
     /**
      * Underlying method to check if a feature is enabled.
-     * @param Feature|null $feature
-     * @param Context $context
-     * @param bool $default
+     * @param Feature|null $feature the feature to check
+     * @param Context $context the context to use
+     * @param bool $default the default value to return if the feature is not found
      * @return bool
      */
     private function isFeatureEnabled(?Feature $feature, Context $context, bool $default = false): bool

--- a/src/Repository/DefaultUnleashRepository.php
+++ b/src/Repository/DefaultUnleashRepository.php
@@ -79,7 +79,7 @@ final class DefaultUnleashRepository implements UnleashRepository
                     ->createRequest('GET', $this->configuration->getUrl() . 'client/features')
                     ->withHeader('UNLEASH-APPNAME', $this->configuration->getAppName())
                     ->withHeader('UNLEASH-INSTANCEID', $this->configuration->getInstanceId())
-                    ->withHeader('Unleash-Client-Spec', '4.2.2')
+                    ->withHeader('Unleash-Client-Spec', '4.2.3')
                 ;
 
                 foreach ($this->configuration->getHeaders() as $name => $value) {
@@ -112,6 +112,8 @@ final class DefaultUnleashRepository implements UnleashRepository
 
             $features = $this->parseFeatures($data);
             $this->setCache($features);
+        } else {
+            echo 'returning from cache';
         }
 
         return $features;

--- a/src/Repository/DefaultUnleashRepository.php
+++ b/src/Repository/DefaultUnleashRepository.php
@@ -112,8 +112,6 @@ final class DefaultUnleashRepository implements UnleashRepository
 
             $features = $this->parseFeatures($data);
             $this->setCache($features);
-        } else {
-            echo 'returning from cache';
         }
 
         return $features;


### PR DESCRIPTION
Fixes https://github.com/Unleash/unleash-client-php/issues/171

1. Updated client spec to 4.2.3
2. Now getVariant will return disabled variant when feature is evaluated to false.