### PR TITLE
feat: add strategy variants support

### DIFF
--- a/src/DTO/DefaultFeatureEnabledResult.php
+++ b/src/DTO/DefaultFeatureEnabledResult.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Unleash\Client\DTO;
+
+final class DefaultFeatureEnabledResult implements FeatureEnabledResult
+{
+    public function __construct(
+        private readonly bool $isEnabled = false,
+        private readonly ?Strategy $strategy = null,
+    ) {
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->isEnabled;
+    }
+
+    public function getStrategy(): ?Strategy
+    {
+        return $this->strategy;
+    }
+}

--- a/src/DTO/DefaultStrategy.php
+++ b/src/DTO/DefaultStrategy.php
@@ -8,12 +8,14 @@ final class DefaultStrategy implements Strategy
      * @param array<string,string> $parameters
      * @param array<Constraint>    $constraints
      * @param array<Segment>       $segments
+     * @param array<Variant>       $variants
      */
     public function __construct(
         private readonly string $name,
         private readonly array $parameters = [],
         private readonly array $constraints = [],
         private readonly array $segments = [],
+        private readonly array $variants = [],
         private readonly bool $nonexistentSegments = false,
     ) {
     }
@@ -45,6 +47,14 @@ final class DefaultStrategy implements Strategy
     public function getSegments(): array
     {
         return $this->segments;
+    }
+
+    /**
+     * @return array<Variant>
+     */
+    public function getVariants(): array
+    {
+        return $this->variants;
     }
 
     public function hasNonexistentSegments(): bool

--- a/src/DTO/FeatureEnabledResult.php
+++ b/src/DTO/FeatureEnabledResult.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Unleash\Client\DTO;
+
+
+interface FeatureEnabledResult
+{
+
+    public function isEnabled(): bool;
+
+    public function getStrategy(): ?Strategy;
+}

--- a/src/DTO/FeatureEnabledResult.php
+++ b/src/DTO/FeatureEnabledResult.php
@@ -2,10 +2,8 @@
 
 namespace Unleash\Client\DTO;
 
-
 interface FeatureEnabledResult
 {
-
     public function isEnabled(): bool;
 
     public function getStrategy(): ?Strategy;

--- a/src/DTO/Strategy.php
+++ b/src/DTO/Strategy.php
@@ -19,4 +19,9 @@ interface Strategy
      * @return array<Constraint>
      */
     public function getConstraints(): array;
+
+    /**
+     * @return array<Variant>
+     */
+    public function getVariants(): array;
 }

--- a/src/DefaultUnleash.php
+++ b/src/DefaultUnleash.php
@@ -28,14 +28,13 @@ final class DefaultUnleash implements Unleash
      * @param iterable<StrategyHandler> $strategyHandlers
      */
     public function __construct(
-        private readonly iterable             $strategyHandlers,
-        private readonly UnleashRepository    $repository,
-        private readonly RegistrationService  $registrationService,
+        private readonly iterable $strategyHandlers,
+        private readonly UnleashRepository $repository,
+        private readonly RegistrationService $registrationService,
         private readonly UnleashConfiguration $configuration,
-        private readonly MetricsHandler       $metricsHandler,
-        private readonly VariantHandler       $variantHandler,
-    )
-    {
+        private readonly MetricsHandler $metricsHandler,
+        private readonly VariantHandler $variantHandler,
+    ) {
         if ($configuration->isAutoRegistrationEnabled()) {
             $this->register();
         }
@@ -76,11 +75,10 @@ final class DefaultUnleash implements Unleash
             return $fallbackVariant;
         }
 
-
         if (empty($strategyVariants)) {
             $variant = $this->variantHandler->selectVariant($feature->getVariants(), $featureName, $context);
         } else {
-            $variant = $this->variantHandler->selectVariant($strategyVariants, $enabledResult->getStrategy()->getParameters()['groupId'] ?? '', $context);
+            $variant = $this->variantHandler->selectVariant($strategyVariants, $enabledResult->getStrategy()?->getParameters()['groupId'] ?? '', $context);
         }
         if ($variant !== null) {
             $this->metricsHandler->handleMetrics($feature, true, $variant);
@@ -110,8 +108,8 @@ final class DefaultUnleash implements Unleash
     /**
      * Finds a feature and posts events if the feature is not found.
      *
-     * @param string $featureName name of the feature to find
-     * @param Context $context the context to use
+     * @param string  $featureName name of the feature to find
+     * @param Context $context     the context to use
      *
      * @return Feature|null
      */
@@ -133,10 +131,8 @@ final class DefaultUnleash implements Unleash
      * Underlying method to check if a feature is enabled.
      *
      * @param Feature|null $feature the feature to check
-     * @param Context $context the context to use
-     * @param bool $default the default value to return if the feature is not found
-     *
-     * @return bool
+     * @param Context      $context the context to use
+     * @param bool         $default the default value to return if the feature is not found
      */
     private function isFeatureEnabled(?Feature $feature, Context $context, bool $default = false): FeatureEnabledResult
     {
@@ -176,6 +172,7 @@ final class DefaultUnleash implements Unleash
             foreach ($handlers as $handler) {
                 if ($handler->isEnabled($strategy, $context)) {
                     $this->metricsHandler->handleMetrics($feature, true);
+
                     return new DefaultFeatureEnabledResult(true, $strategy);
                 }
             }

--- a/src/Repository/DefaultUnleashRepository.php
+++ b/src/Repository/DefaultUnleashRepository.php
@@ -20,6 +20,7 @@ use Unleash\Client\DTO\DefaultVariantOverride;
 use Unleash\Client\DTO\DefaultVariantPayload;
 use Unleash\Client\DTO\Feature;
 use Unleash\Client\DTO\Segment;
+use Unleash\Client\DTO\Variant;
 use Unleash\Client\Enum\CacheKey;
 use Unleash\Client\Enum\Stickiness;
 use Unleash\Client\Event\FetchingDataFailedEvent;
@@ -36,6 +37,24 @@ use Unleash\Client\Exception\InvalidValueException;
  *     inverted?: bool,
  *     caseInsensitive?: bool
  * }
+ * @phpstan-type VariantArray array{
+ *      contextName: string,
+ *      name: string,
+ *      weight: int,
+ *      stickiness?: string,
+ *      payload?: VariantPayload,
+ *      overrides?: array<VariantOverride>,
+ *  }
+ * @phpstan-type VariantPayload array{
+ *        type: string,
+ *        value: string,
+ *    }
+ * @phpstan-type VariantOverride array{
+ *       contextName: string,
+ *       values: array<string>,
+ *       type:string,
+ *       value: string,
+ *   }
  */
 final class DefaultUnleashRepository implements UnleashRepository
 {
@@ -274,11 +293,16 @@ final class DefaultUnleashRepository implements UnleashRepository
         return $constraints;
     }
 
+    /**
+     * @param array<VariantArray> $variantsRaw
+     *
+     * @return array<Variant>
+     */
     private function parseVariants(array $variantsRaw): array
     {
         $variants = [];
 
-        foreach ($variantsRaw?? [] as $variant) {
+        foreach ($variantsRaw as $variant) {
             $overrides = [];
             foreach ($variant['overrides'] ?? [] as $override) {
                 $overrides[] = new DefaultVariantOverride($override['contextName'], $override['values']);

--- a/src/Repository/DefaultUnleashRepository.php
+++ b/src/Repository/DefaultUnleashRepository.php
@@ -98,7 +98,7 @@ final class DefaultUnleashRepository implements UnleashRepository
                     ->createRequest('GET', $this->configuration->getUrl() . 'client/features')
                     ->withHeader('UNLEASH-APPNAME', $this->configuration->getAppName())
                     ->withHeader('UNLEASH-INSTANCEID', $this->configuration->getInstanceId())
-                    ->withHeader('Unleash-Client-Spec', '4.2.3')
+                    ->withHeader('Unleash-Client-Spec', '4.3.2')
                 ;
 
                 foreach ($this->configuration->getHeaders() as $name => $value) {

--- a/src/Variant/DefaultVariantHandler.php
+++ b/src/Variant/DefaultVariantHandler.php
@@ -5,7 +5,6 @@ namespace Unleash\Client\Variant;
 use JetBrains\PhpStorm\Pure;
 use Unleash\Client\Configuration\Context;
 use Unleash\Client\DTO\DefaultVariant;
-use Unleash\Client\DTO\Feature;
 use Unleash\Client\DTO\Variant;
 use Unleash\Client\Enum\Stickiness;
 use Unleash\Client\Stickiness\StickinessCalculator;
@@ -26,7 +25,10 @@ final class DefaultVariantHandler implements VariantHandler
         );
     }
 
-    public function selectVariant(array $variants, string $groupId,  Context $context): ?Variant
+    /**
+     * @param array<Variant> $variants
+     */
+    public function selectVariant(array $variants, string $groupId, Context $context): ?Variant
     {
         $totalWeight = 0;
         foreach ($variants as $variant) {
@@ -66,6 +68,9 @@ final class DefaultVariantHandler implements VariantHandler
         // @codeCoverageIgnoreEnd
     }
 
+    /**
+     * @param array<Variant> $variants
+     */
     private function findOverriddenVariant(array $variants, Context $context): ?Variant
     {
         foreach ($variants as $variant) {
@@ -79,6 +84,9 @@ final class DefaultVariantHandler implements VariantHandler
         return null;
     }
 
+    /**
+     * @param array<Variant> $variants
+     */
     private function calculateStickiness(
         array $variants,
         string $groupId,

--- a/src/Variant/VariantHandler.php
+++ b/src/Variant/VariantHandler.php
@@ -10,5 +10,5 @@ interface VariantHandler
 {
     public function getDefaultVariant(): Variant;
 
-    public function selectVariant(Feature $feature, Context $context): ?Variant;
+    public function selectVariant(array $variants, string $groupId, Context $context): ?Variant;
 }

--- a/src/Variant/VariantHandler.php
+++ b/src/Variant/VariantHandler.php
@@ -3,12 +3,14 @@
 namespace Unleash\Client\Variant;
 
 use Unleash\Client\Configuration\Context;
-use Unleash\Client\DTO\Feature;
 use Unleash\Client\DTO\Variant;
 
 interface VariantHandler
 {
     public function getDefaultVariant(): Variant;
 
+    /**
+     * @param array<Variant> $variants
+     */
     public function selectVariant(array $variants, string $groupId, Context $context): ?Variant;
 }

--- a/tests/AbstractHttpClientTest.php
+++ b/tests/AbstractHttpClientTest.php
@@ -103,7 +103,7 @@ abstract class AbstractHttpClientTest extends TestCase
                 return new DefaultVariant('test', false);
             }
 
-            public function selectVariant(Feature $feature, Context $context): ?Variant
+            public function selectVariant(array $variants, string $groupId, Context $context): ?Variant
             {
                 return null;
             }

--- a/tests/TestHelpers/DependencyContainer/ConfigurationAwareVariantHandler.php
+++ b/tests/TestHelpers/DependencyContainer/ConfigurationAwareVariantHandler.php
@@ -5,7 +5,6 @@ namespace Unleash\Client\Tests\TestHelpers\DependencyContainer;
 use Unleash\Client\Configuration\Context;
 use Unleash\Client\Configuration\UnleashConfiguration;
 use Unleash\Client\DTO\DefaultVariant;
-use Unleash\Client\DTO\Feature;
 use Unleash\Client\DTO\Variant;
 use Unleash\Client\Helper\Builder\ConfigurationAware;
 use Unleash\Client\Variant\VariantHandler;
@@ -27,7 +26,7 @@ final class ConfigurationAwareVariantHandler implements VariantHandler, Configur
         return new DefaultVariant('test', false);
     }
 
-    public function selectVariant(Feature $feature, Context $context): ?Variant
+    public function selectVariant(array $variants, string $groupId, Context $context): ?Variant
     {
         return null;
     }

--- a/tests/UnleashBuilderTest.php
+++ b/tests/UnleashBuilderTest.php
@@ -798,7 +798,7 @@ final class UnleashBuilderTest extends TestCase
                 return new DefaultVariant('test', false);
             }
 
-            public function selectVariant(Feature $feature, Context $context): ?Variant
+            public function selectVariant(array $variants, string $groupId, Context $context): ?Variant
             {
                 return null;
             }

--- a/tests/Variant/DefaultVariantHandlerTest.php
+++ b/tests/Variant/DefaultVariantHandlerTest.php
@@ -35,7 +35,7 @@ final class DefaultVariantHandlerTest extends TestCase
             ]
         );
 
-        self::assertNull($instance->selectVariant($feature, new UnleashContext()));
+        self::assertNull($instance->selectVariant($feature->getVariants(), $feature->getName(), new UnleashContext()));
 
         $feature = new DefaultFeature(
             'test',
@@ -47,7 +47,7 @@ final class DefaultVariantHandlerTest extends TestCase
             ]
         );
 
-        self::assertEquals('test2', $instance->selectVariant($feature, new UnleashContext())->getName());
+        self::assertEquals('test2', $instance->selectVariant($feature->getVariants(), $feature->getName(), new UnleashContext())->getName());
 
         $feature = new DefaultFeature(
             'test',
@@ -58,7 +58,7 @@ final class DefaultVariantHandlerTest extends TestCase
                 new DefaultVariant('test2', true, 1, Stickiness::USER_ID),
             ]
         );
-        self::assertEquals('test2', $instance->selectVariant($feature, new UnleashContext('125'))->getName());
-        self::assertEquals('test', $instance->selectVariant($feature, new UnleashContext('126'))->getName());
+        self::assertEquals('test2', $instance->selectVariant($feature->getVariants(), $feature->getName(), new UnleashContext('125'))->getName());
+        self::assertEquals('test', $instance->selectVariant($feature->getVariants(), $feature->getName(), new UnleashContext('126'))->getName());
     }
 }


### PR DESCRIPTION
Add support for strategy variants.

https://docs.getunleash.io/reference/strategy-variants

To do it most efficiently, when feature is evaluated true, the underlying `isFeatureEnabled` method should return also the variant from the strategy returned true. Public contract remains the same.