### PR TITLE
fix: use a fixed hash seed for variant hashing

### DIFF
--- a/src/Stickiness/MurmurHashCalculator.php
+++ b/src/Stickiness/MurmurHashCalculator.php
@@ -6,8 +6,8 @@ use lastguest\Murmur;
 
 final class MurmurHashCalculator implements StickinessCalculator
 {
-    public function calculate(string $id, string $groupId, int $normalizer = 100): int
+    public function calculate(string $id, string $groupId, int $normalizer = 100, int $seed = 0): int
     {
-        return Murmur::hash3_int("{$groupId}:{$id}") % $normalizer + 1;
+        return Murmur::hash3_int("{$groupId}:{$id}", $seed) % $normalizer + 1;
     }
 }

--- a/src/Stickiness/StickinessCalculator.php
+++ b/src/Stickiness/StickinessCalculator.php
@@ -4,5 +4,5 @@ namespace Unleash\Client\Stickiness;
 
 interface StickinessCalculator
 {
-    public function calculate(string $id, string $groupId, int $normalizer = 100): int;
+    public function calculate(string $id, string $groupId, int $normalizer = 100, int $seed = 0): int;
 }

--- a/src/Variant/DefaultVariantHandler.php
+++ b/src/Variant/DefaultVariantHandler.php
@@ -11,6 +11,8 @@ use Unleash\Client\Stickiness\StickinessCalculator;
 
 final class DefaultVariantHandler implements VariantHandler
 {
+    const VARIANT_HASH_SEED = 86028157;
+
     public function __construct(
         private readonly StickinessCalculator $stickinessCalculator,
     ) {
@@ -94,7 +96,7 @@ final class DefaultVariantHandler implements VariantHandler
         int $totalWeight
     ): int {
         $stickiness = $variants[0]->getStickiness();
-        if ($stickiness !== Stickiness::DEFAULT) {
+        if ($stickiness !== Stickiness::DEFAULT ) {
             $seed = $context->findContextValue($stickiness) ?? $this->randomString();
         } else {
             $seed = $context->getCurrentUserId()
@@ -103,7 +105,7 @@ final class DefaultVariantHandler implements VariantHandler
                 ?? $this->randomString();
         }
 
-        return $this->stickinessCalculator->calculate($seed, $groupId, $totalWeight);
+        return $this->stickinessCalculator->calculate($seed, $groupId, $totalWeight, $seed = DefaultVariantHandler::VARIANT_HASH_SEED);
     }
 
     private function randomString(): string

--- a/src/Variant/DefaultVariantHandler.php
+++ b/src/Variant/DefaultVariantHandler.php
@@ -11,7 +11,7 @@ use Unleash\Client\Stickiness\StickinessCalculator;
 
 final class DefaultVariantHandler implements VariantHandler
 {
-    const VARIANT_HASH_SEED = 86028157;
+    private const VARIANT_HASH_SEED = 86028157;
 
     public function __construct(
         private readonly StickinessCalculator $stickinessCalculator,
@@ -96,7 +96,7 @@ final class DefaultVariantHandler implements VariantHandler
         int $totalWeight
     ): int {
         $stickiness = $variants[0]->getStickiness();
-        if ($stickiness !== Stickiness::DEFAULT ) {
+        if ($stickiness !== Stickiness::DEFAULT) {
             $seed = $context->findContextValue($stickiness) ?? $this->randomString();
         } else {
             $seed = $context->getCurrentUserId()


### PR DESCRIPTION
This forces the variant distribution to use a seeded hash, rather than falling back to the default of 0.

This fixes an issue in the variant distribution when gradual rollout is at play, since that narrows down the potential buckets before variants kick in. Previously, we'd see very non random distributions of variants in those cases. This change allows for a more statistically sane distribution

This PR hasn't updated the client-spec, since this requires dependent features to get merged first in order for the specs to pass. Manually validated by removing the dependent features test case and running the rest of the tests. Because of this, this PR won't pass until that feature gets merged or we backport a version for the client spec