### PR TITLE
Separate MetricsCache from common Cache.

### DIFF
--- a/README.md
+++ b/README.md
@@ -948,6 +948,7 @@ $unleash = UnleashBuilder::create()
     ->withMetricsEnabled(false) // turn off metric sending
     ->withMetricsEnabled(true) // turn on metric sending
     ->withMetricsInterval(10_000) // interval in milliseconds (10 seconds)
+    ->withMetricsCacheHandler(new Psr16Cache(new RedisAdapter())) // use custom cache handler for metrics, defaults to standard cache handler
     ->build();
 
 // the metric will be collected but not sent immediately

--- a/src/Configuration/UnleashConfiguration.php
+++ b/src/Configuration/UnleashConfiguration.php
@@ -45,6 +45,7 @@ final class UnleashConfiguration
         private int $staleTtl = 30 * 60,
         private ?CacheInterface $staleCache = null,
         private ?string $proxyKey = null,
+        private ?CacheInterface $metricsCache = null,
     ) {
         $this->contextProvider ??= new DefaultUnleashContextProvider();
         if ($defaultContext !== null) {
@@ -64,6 +65,11 @@ final class UnleashConfiguration
     public function getStaleCache(): CacheInterface
     {
         return $this->staleCache ?? $this->getCache();
+    }
+
+    public function getMetricsCache(): CacheInterface
+    {
+        return $this->metricsCache ?? $this->getCache();
     }
 
     public function getUrl(): string
@@ -113,6 +119,13 @@ final class UnleashConfiguration
     public function setStaleCache(?CacheInterface $cache): self
     {
         $this->staleCache = $cache;
+
+        return $this;
+    }
+
+    public function setMetricsCache(?CacheInterface $cache): self
+    {
+        $this->metricsCache = $cache;
 
         return $this;
     }

--- a/src/Metrics/DefaultMetricsHandler.php
+++ b/src/Metrics/DefaultMetricsHandler.php
@@ -33,7 +33,7 @@ final class DefaultMetricsHandler implements MetricsHandler
 
     private function getOrCreateBucket(): MetricsBucket
     {
-        $cache = $this->configuration->getCache();
+        $cache = $this->configuration->getMetricsCache();
 
         $bucket = null;
         if ($cache->has(CacheKey::METRICS_BUCKET)) {
@@ -62,7 +62,7 @@ final class DefaultMetricsHandler implements MetricsHandler
     {
         $bucket->setEndDate(new DateTimeImmutable());
         $this->metricsSender->sendMetrics($bucket);
-        $cache = $this->configuration->getCache();
+        $cache = $this->configuration->getMetricsCache();
         if ($cache->has(CacheKey::METRICS_BUCKET)) {
             $cache->delete(CacheKey::METRICS_BUCKET);
         }
@@ -70,7 +70,7 @@ final class DefaultMetricsHandler implements MetricsHandler
 
     private function store(MetricsBucket $bucket): void
     {
-        $cache = $this->configuration->getCache();
+        $cache = $this->configuration->getMetricsCache();
         $cache->set(CacheKey::METRICS_BUCKET, $bucket);
     }
 }

--- a/src/UnleashBuilder.php
+++ b/src/UnleashBuilder.php
@@ -76,6 +76,8 @@ final class UnleashBuilder
 
     private ?CacheInterface $staleCache = null;
 
+    private ?CacheInterface $metricsCache = null;
+
     private ?int $cacheTtl = null;
 
     private ?int $staleTtl = null;
@@ -221,6 +223,12 @@ final class UnleashBuilder
     public function withStaleCacheHandler(?CacheInterface $cache): self
     {
         return $this->with('staleCache', $cache);
+    }
+
+    #[Pure]
+    public function withMetricsCacheHandler(?CacheInterface $cache): self
+    {
+        return $this->with('metricsCache', $cache);
     }
 
     #[Pure]
@@ -412,6 +420,7 @@ final class UnleashBuilder
         }
         assert($cache instanceof CacheInterface);
         $staleCache = $this->staleCache ?? $cache;
+        $metricsCache = $this->metricsCache ?? $cache;
 
         $httpClient = $this->httpClient;
         if ($httpClient === null) {
@@ -488,6 +497,7 @@ final class UnleashBuilder
         $configuration
             ->setCache($cache)
             ->setStaleCache($staleCache)
+            ->setMetricsCache($metricsCache)
             ->setTtl($this->cacheTtl ?? $configuration->getTtl())
             ->setStaleTtl($this->staleTtl ?? $configuration->getStaleTtl())
             ->setMetricsEnabled($this->metricsEnabled ?? $configuration->isMetricsEnabled())

--- a/tests/UnleashBuilderTest.php
+++ b/tests/UnleashBuilderTest.php
@@ -773,6 +773,29 @@ final class UnleashBuilderTest extends TestCase
         self::assertSame($cache1, $this->getConfiguration($instance->build())->getCache());
     }
 
+    public function testWithMetricsCacheHandler()
+    {
+        $cache1 = $this->getCache();
+        $cache2 = $this->getCache();
+
+        $instance = $this->instance->withFetchingEnabled(false);
+        self::assertNull($this->getProperty($instance, 'metricsCache'));
+        self::assertNotNull($this->getConfiguration($instance->build())->getMetricsCache());
+
+        $instance = $this->instance->withFetchingEnabled(false)->withCacheHandler($cache1);
+        self::assertNull($this->getProperty($instance, 'metricsCache'));
+        self::assertSame($cache1, $this->getConfiguration($instance->build())->getMetricsCache());
+
+        $instance = $this->instance
+            ->withFetchingEnabled(false)
+            ->withCacheHandler($cache1)
+            ->withMetricsCacheHandler($cache2)
+        ;
+        self::assertSame($cache2, $this->getProperty($instance, 'metricsCache'));
+        self::assertSame($cache2, $this->getConfiguration($instance->build())->getMetricsCache());
+        self::assertSame($cache1, $this->getConfiguration($instance->build())->getCache());
+    }
+
     public function testWithMetricsHandler()
     {
         $metricsHandler = new class implements MetricsHandler {


### PR DESCRIPTION
# Description

Previously, the metrics cache relied on the shared cache. When ArrayCache or a similar short-lived shared cache is used, it effectively ignores  "metricsInterval" because ArrayCache lives up until the request ends.
In high-load applications, the "metricsInterval=0" approach is ineffective because it will increase the overall page load time.

By separating the Metrics cache from the shared one, "metricsInterval" is honored. Feature cache may have any suitable implementation it needs.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
