### PR TITLE
Do not store invalid response

### DIFF
--- a/src/Repository/DefaultUnleashRepository.php
+++ b/src/Repository/DefaultUnleashRepository.php
@@ -180,6 +180,7 @@ final readonly class DefaultUnleashRepository implements UnleashRepository
 
     /**
      * @throws JsonException
+     * @param array $body
      *
      * @return array<Feature>
      */

--- a/src/Repository/DefaultUnleashRepository.php
+++ b/src/Repository/DefaultUnleashRepository.php
@@ -55,6 +55,24 @@ use Unleash\Client\Exception\InvalidValueException;
  *       type:string,
  *       value: string,
  *   }
+ * @phpstan-type StrategyArray array{
+ *       constraints?: array<ConstraintArray>,
+ *       variants?: array<VariantArray>,
+ *       segments?: array<string>,
+ *       name: string,
+ *       parameters: array<string, string>,
+ *   }
+ * @phpstan-type SegmentArray array{
+ *       id: int,
+ *       constraints: array<ConstraintArray>,
+ *   }
+ * @phpstan-type FeatureArray array{
+ *       strategies: array<StrategyArray>,
+ *       variants: array<VariantArray>,
+ *       name: string,
+ *       enabled: bool,
+ *       impressionData?: bool,
+ *   }
  */
 final readonly class DefaultUnleashRepository implements UnleashRepository
 {
@@ -141,6 +159,7 @@ final readonly class DefaultUnleashRepository implements UnleashRepository
                 $data = json_decode($rawData, true);
             }
 
+            assert(is_array($data));
             $features = $this->parseFeatures($data);
             $this->setCache($features);
         }
@@ -179,8 +198,7 @@ final readonly class DefaultUnleashRepository implements UnleashRepository
     }
 
     /**
-     * @throws JsonException
-     * @param array $body
+     * @param array{segments?: array<SegmentArray>, features?: array<FeatureArray>} $body
      *
      * @return array<Feature>
      */
@@ -263,7 +281,7 @@ final readonly class DefaultUnleashRepository implements UnleashRepository
     }
 
     /**
-     * @param array<array{id: int, constraints: array<ConstraintArray>}> $segmentsRaw
+     * @param array<SegmentArray> $segmentsRaw
      *
      * @return array<Segment>
      */

--- a/src/Repository/DefaultUnleashRepository.php
+++ b/src/Repository/DefaultUnleashRepository.php
@@ -109,6 +109,7 @@ final readonly class DefaultUnleashRepository implements UnleashRepository
                     $response = $this->httpClient->sendRequest($request);
                     if ($response->getStatusCode() === 200) {
                         $data = (string) $response->getBody();
+                        json_decode($data, true, 512, JSON_THROW_ON_ERROR);
                         $this->setLastValidState($data);
                     } else {
                         throw new HttpResponseException("Invalid status code: '{$response->getStatusCode()}'");

--- a/tests/Repository/DefaultUnleashRepositoryTest.php
+++ b/tests/Repository/DefaultUnleashRepositoryTest.php
@@ -8,7 +8,6 @@ use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use JsonException;
 use LogicException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;

--- a/tests/Repository/DefaultUnleashRepositoryTest.php
+++ b/tests/Repository/DefaultUnleashRepositoryTest.php
@@ -443,7 +443,7 @@ final class DefaultUnleashRepositoryTest extends AbstractHttpClientTestCase
         $eventDispatcher->addListener(
             UnleashEvents::FETCHING_DATA_FAILED,
             function (FetchingDataFailedEvent $event) use (&$failCount): void {
-                self::assertInstanceOf(JsonException::class, $event->getException());
+                self::assertInstanceOf(InvalidValueException::class, $event->getException());
                 ++$failCount;
             }
         );


### PR DESCRIPTION
# Description

When the `max_duration` option is used in the PSR18 client, it may result in a partial/corrupted body that is stored without any checks for its validity. Then in `DefaultUnleashRepository:parseFeatures`, the JsonException is thrown and is bubbled up for the end-user. Additionally, the Stale cache is polluted.

More on the error: https://github.com/symfony/symfony/issues/52490

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [ ] Spec Tests
- [ ] Integration tests / Manual Tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
