### PR TITLE
Feat: Compact metrics

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,35 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.mkShell {
+    nativeBuildInputs = with pkgs.buildPackages;
+    let
+        unstable = import (builtins.fetchTarball https://github.com/nixos/nixpkgs/tarball/master) {};
+        php83 = unstable.php83.buildEnv {
+            extensions = ({ enabled, all }: enabled ++ (with all; [
+                apcu
+                ctype
+                iconv
+                intl
+                mbstring
+                pdo
+                redis
+                xdebug
+                xsl
+            ]));
+            extraConfig = ''
+                memory_limit=8G
+                xdebug.mode=debug
+                apc.enable_cli=1
+                apc.enabled=1
+            '';
+        };
+     in
+     [
+        php83
+        php83.packages.composer
+        php83.extensions.redis
+        php83.extensions.xsl
+        php83.extensions.mbstring
+        php83.extensions.apcu
+        git
+    ];
+}

--- a/src/Configuration/UnleashConfiguration.php
+++ b/src/Configuration/UnleashConfiguration.php
@@ -13,6 +13,8 @@ use Unleash\Client\Bootstrap\DefaultBootstrapHandler;
 use Unleash\Client\Bootstrap\EmptyBootstrapProvider;
 use Unleash\Client\ContextProvider\DefaultUnleashContextProvider;
 use Unleash\Client\ContextProvider\UnleashContextProvider;
+use Unleash\Client\Metrics\DefaultMetricsBucketSerializer;
+use Unleash\Client\Metrics\MetricsBucketSerializer;
 
 final class UnleashConfiguration
 {
@@ -38,6 +40,7 @@ final class UnleashConfiguration
         private ?CacheInterface $staleCache = null,
         private ?string $proxyKey = null,
         private ?CacheInterface $metricsCache = null,
+        private MetricsBucketSerializer $metricsBucketSerializer = new DefaultMetricsBucketSerializer(),
     ) {
         $this->contextProvider ??= new DefaultUnleashContextProvider();
     }
@@ -283,6 +286,18 @@ final class UnleashConfiguration
     public function setStaleTtl(int $staleTtl): self
     {
         $this->staleTtl = $staleTtl;
+
+        return $this;
+    }
+
+    public function getMetricsBucketSerializer(): MetricsBucketSerializer
+    {
+        return $this->metricsBucketSerializer;
+    }
+
+    public function setMetricsBucketSerializer(MetricsBucketSerializer $metricsBucketSerializer): self
+    {
+        $this->metricsBucketSerializer = $metricsBucketSerializer;
 
         return $this;
     }

--- a/src/Metrics/DefaultMetricsBucketSerializer.php
+++ b/src/Metrics/DefaultMetricsBucketSerializer.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Unleash\Client\Metrics;
+
+use DateTimeImmutable;
+use Unleash\Client\DTO\DefaultFeature;
+use Unleash\Client\DTO\DefaultVariant;
+
+final readonly class DefaultMetricsBucketSerializer implements MetricsBucketSerializer
+{
+    public function serialize(MetricsBucket $bucket): string
+    {
+        $serialized = $bucket->getStartDate()->getTimestamp() . ';';
+        if (!count($bucket->getToggles())) {
+            $serialized .= ';';
+        }
+        foreach ($bucket->getToggles() as $toggle) {
+            $variantName = $toggle->getVariant()?->getName() ?? '~';
+            $serialized .= "{$toggle->getFeature()->getName()}:";
+            $serialized .= $toggle->isSuccess() ? '1' : '0';
+            $serialized .= ":{$variantName},";
+        }
+        $serialized = substr($serialized, 0, -1);
+        $serialized .= ';';
+        $serialized .= $bucket->getEndDate()?->getTimestamp() ?? '~';
+
+        return $serialized;
+    }
+
+    public function deserialize(string $serialized): MetricsBucket
+    {
+        [$startDate, $toggles, $endDate] = explode(';', $serialized);
+        $startDate = (new DateTimeImmutable())->setTimestamp((int) $startDate);
+        $endDate = $endDate === '~' ? null : (new DateTimeImmutable())->setTimestamp((int) $endDate);
+        $toggles = array_filter(explode(',', $toggles));
+
+        $bucket = new MetricsBucket($startDate, $endDate);
+
+        foreach ($toggles as $toggle) {
+            [$name, $enabled, $variant] = explode(':', $toggle);
+            $enabled = $enabled === '1';
+            $variant = $variant === '~' ? null : new DefaultVariant($variant, true);
+            $bucket->addToggle(new MetricsBucketToggle(
+                feature: new DefaultFeature(name: $name, enabled: true, strategies: []),
+                success: $enabled,
+                variant: $variant,
+            ));
+        }
+
+        return $bucket;
+    }
+}

--- a/src/Metrics/DefaultMetricsHandler.php
+++ b/src/Metrics/DefaultMetricsHandler.php
@@ -38,6 +38,9 @@ final readonly class DefaultMetricsHandler implements MetricsHandler
         $bucket = null;
         if ($cache->has(CacheKey::METRICS_BUCKET)) {
             $bucket = $cache->get(CacheKey::METRICS_BUCKET);
+            if (is_string($bucket)) {
+                $bucket = $this->configuration->getMetricsBucketSerializer()->deserialize($bucket);
+            }
             assert($bucket instanceof MetricsBucket || $bucket === null);
         }
 
@@ -71,6 +74,6 @@ final readonly class DefaultMetricsHandler implements MetricsHandler
     private function store(MetricsBucket $bucket): void
     {
         $cache = $this->configuration->getMetricsCache();
-        $cache->set(CacheKey::METRICS_BUCKET, $bucket);
+        $cache->set(CacheKey::METRICS_BUCKET, $this->configuration->getMetricsBucketSerializer()->serialize($bucket));
     }
 }

--- a/src/Metrics/MetricsBucket.php
+++ b/src/Metrics/MetricsBucket.php
@@ -42,6 +42,19 @@ final class MetricsBucket implements JsonSerializable
         return $this;
     }
 
+    public function getEndDate(): ?DateTimeInterface
+    {
+        return $this->endDate;
+    }
+
+    /**
+     * @return array<MetricsBucketToggle>
+     */
+    public function getToggles(): array
+    {
+        return $this->toggles;
+    }
+
     /**
      * @return array<string,mixed>
      */

--- a/src/Metrics/MetricsBucketSerializer.php
+++ b/src/Metrics/MetricsBucketSerializer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Unleash\Client\Metrics;
+
+interface MetricsBucketSerializer
+{
+    public function serialize(MetricsBucket $bucket): string;
+
+    public function deserialize(string $serialized): MetricsBucket;
+}

--- a/src/UnleashBuilder.php
+++ b/src/UnleashBuilder.php
@@ -37,8 +37,10 @@ use Unleash\Client\Helper\Builder\StaleCacheAware;
 use Unleash\Client\Helper\Builder\StickinessCalculatorAware;
 use Unleash\Client\Helper\DefaultImplementationLocator;
 use Unleash\Client\Helper\UnleashBuilderContainer;
+use Unleash\Client\Metrics\DefaultMetricsBucketSerializer;
 use Unleash\Client\Metrics\DefaultMetricsHandler;
 use Unleash\Client\Metrics\DefaultMetricsSender;
+use Unleash\Client\Metrics\MetricsBucketSerializer;
 use Unleash\Client\Metrics\MetricsHandler;
 use Unleash\Client\Repository\DefaultUnleashProxyRepository;
 use Unleash\Client\Repository\DefaultUnleashRepository;
@@ -120,6 +122,8 @@ final class UnleashBuilder
     private ?MetricsHandler $metricsHandler = null;
 
     private ?VariantHandler $variantHandler = null;
+
+    private ?MetricsBucketSerializer $metricsBucketSerializer = null;
 
     public function __construct()
     {
@@ -366,6 +370,12 @@ final class UnleashBuilder
         return $this->with('proxyKey', $proxyKey);
     }
 
+    #[Pure]
+    public function withMetricsBucketSerializer(?MetricsBucketSerializer $metricsBucketSerializer): self
+    {
+        return $this->with('metricsBucketSerializer', $metricsBucketSerializer);
+    }
+
     public function build(): Unleash
     {
         // basic scalar attributes
@@ -464,6 +474,7 @@ final class UnleashBuilder
         foreach ($this->eventSubscribers as $eventSubscriber) {
             $eventDispatcher->addSubscriber($eventSubscriber);
         }
+        $metricsBucketSerializer = $this->metricsBucketSerializer ?? new DefaultMetricsBucketSerializer();
 
         // initialize services
         $this->initializeServices($contextProvider, $dependencyContainer);
@@ -492,7 +503,7 @@ final class UnleashBuilder
             ->setBootstrapProvider($bootstrapProvider)
             ->setFetchingEnabled($this->fetchingEnabled)
             ->setEventDispatcher($eventDispatcher)
-        ;
+            ->setMetricsBucketSerializer($metricsBucketSerializer);
 
         // runtime-unchangeable blocks of Unleash
 

--- a/src/UnleashBuilder.php
+++ b/src/UnleashBuilder.php
@@ -503,7 +503,8 @@ final class UnleashBuilder
             ->setBootstrapProvider($bootstrapProvider)
             ->setFetchingEnabled($this->fetchingEnabled)
             ->setEventDispatcher($eventDispatcher)
-            ->setMetricsBucketSerializer($metricsBucketSerializer);
+            ->setMetricsBucketSerializer($metricsBucketSerializer)
+        ;
 
         // runtime-unchangeable blocks of Unleash
 

--- a/tests/Metrics/DefaultMetricsBucketSerializerTest.php
+++ b/tests/Metrics/DefaultMetricsBucketSerializerTest.php
@@ -44,31 +44,31 @@ final class DefaultMetricsBucketSerializerTest extends TestCase
                 ->addToggle(new MetricsBucketToggle(
                     new DefaultFeature('test', true, []),
                     true,
-                    new DefaultVariant('test1', true),
+                    new DefaultVariant('test1', true)
                 ))
                 ->addToggle(new MetricsBucketToggle(
                     new DefaultFeature('test', true, []),
                     false,
-                    new DefaultVariant('test1', true),
+                    new DefaultVariant('test1', true)
                 ))
                 ->addToggle(new MetricsBucketToggle(
                     new DefaultFeature('test', true, []),
                     true,
-                    new DefaultVariant('test1', true),
+                    new DefaultVariant('test1', true)
+                ))
+                ->addToggle(new MetricsBucketToggle(
+                    new DefaultFeature('test', true, []),
+                    true
                 ))
                 ->addToggle(new MetricsBucketToggle(
                     new DefaultFeature('test', true, []),
                     true,
+                    new DefaultVariant('test2', true)
                 ))
                 ->addToggle(new MetricsBucketToggle(
                     new DefaultFeature('test', true, []),
                     true,
-                    new DefaultVariant('test2', true),
-                ))
-                ->addToggle(new MetricsBucketToggle(
-                    new DefaultFeature('test', true, []),
-                    true,
-                    new DefaultVariant('test3', true),
+                    new DefaultVariant('test3', true)
                 )),
         ];
         yield [
@@ -76,8 +76,8 @@ final class DefaultMetricsBucketSerializerTest extends TestCase
                 ->addToggle(new MetricsBucketToggle(
                     new DefaultFeature('test', true, []),
                     true,
-                    new DefaultVariant('test1', true),
-                )),
+                    new DefaultVariant('test1', true)
+                ))
         ];
     }
 }

--- a/tests/Metrics/DefaultMetricsBucketSerializerTest.php
+++ b/tests/Metrics/DefaultMetricsBucketSerializerTest.php
@@ -23,7 +23,7 @@ final class DefaultMetricsBucketSerializerTest extends TestCase
         self::assertSame($bucket->jsonSerialize(), $deserialized->jsonSerialize());
     }
 
-    private function serializeDeserializeData(): iterable
+    public function serializeDeserializeData(): iterable
     {
         yield [new MetricsBucket(new DateTimeImmutable(), new DateTimeImmutable('+5 seconds'))];
         yield [

--- a/tests/Metrics/DefaultMetricsBucketSerializerTest.php
+++ b/tests/Metrics/DefaultMetricsBucketSerializerTest.php
@@ -77,7 +77,7 @@ final class DefaultMetricsBucketSerializerTest extends TestCase
                     new DefaultFeature('test', true, []),
                     true,
                     new DefaultVariant('test1', true)
-                ))
+                )),
         ];
     }
 }

--- a/tests/Metrics/DefaultMetricsBucketSerializerTest.php
+++ b/tests/Metrics/DefaultMetricsBucketSerializerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Unleash\Client\Tests\Metrics;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use Unleash\Client\DTO\DefaultFeature;
+use Unleash\Client\DTO\DefaultVariant;
+use Unleash\Client\Metrics\DefaultMetricsBucketSerializer;
+use Unleash\Client\Metrics\MetricsBucket;
+use Unleash\Client\Metrics\MetricsBucketToggle;
+
+final class DefaultMetricsBucketSerializerTest extends TestCase
+{
+    /**
+     * @dataProvider serializeDeserializeData
+     */
+    public function testSerializeDeserialize(MetricsBucket $bucket)
+    {
+        $instance = new DefaultMetricsBucketSerializer();
+        $deserialized = $instance->deserialize($instance->serialize($bucket));
+
+        self::assertSame($bucket->jsonSerialize(), $deserialized->jsonSerialize());
+    }
+
+    private function serializeDeserializeData(): iterable
+    {
+        yield [new MetricsBucket(new DateTimeImmutable(), new DateTimeImmutable('+5 seconds'))];
+        yield [
+            (new MetricsBucket(new DateTimeImmutable(), new DateTimeImmutable('+5 seconds')))
+                ->addToggle(new MetricsBucketToggle(new DefaultFeature('test', true, []), true)),
+        ];
+        yield [
+            (new MetricsBucket(new DateTimeImmutable(), new DateTimeImmutable('+5 seconds')))
+                ->addToggle(new MetricsBucketToggle(new DefaultFeature('test', true, []), true))
+                ->addToggle(new MetricsBucketToggle(new DefaultFeature('test', true, []), true))
+                ->addToggle(new MetricsBucketToggle(new DefaultFeature('test', true, []), true))
+                ->addToggle(new MetricsBucketToggle(new DefaultFeature('test', true, []), false))
+                ->addToggle(new MetricsBucketToggle(new DefaultFeature('test', true, []), false))
+                ->addToggle(new MetricsBucketToggle(new DefaultFeature('test', true, []), false)),
+        ];
+        yield [
+            (new MetricsBucket(new DateTimeImmutable(), new DateTimeImmutable('+5 seconds')))
+                ->addToggle(new MetricsBucketToggle(
+                    new DefaultFeature('test', true, []),
+                    true,
+                    new DefaultVariant('test1', true),
+                ))
+                ->addToggle(new MetricsBucketToggle(
+                    new DefaultFeature('test', true, []),
+                    false,
+                    new DefaultVariant('test1', true),
+                ))
+                ->addToggle(new MetricsBucketToggle(
+                    new DefaultFeature('test', true, []),
+                    true,
+                    new DefaultVariant('test1', true),
+                ))
+                ->addToggle(new MetricsBucketToggle(
+                    new DefaultFeature('test', true, []),
+                    true,
+                ))
+                ->addToggle(new MetricsBucketToggle(
+                    new DefaultFeature('test', true, []),
+                    true,
+                    new DefaultVariant('test2', true),
+                ))
+                ->addToggle(new MetricsBucketToggle(
+                    new DefaultFeature('test', true, []),
+                    true,
+                    new DefaultVariant('test3', true),
+                )),
+        ];
+        yield [
+            (new MetricsBucket(new DateTimeImmutable(), new DateTimeImmutable('+5 seconds')))
+                ->addToggle(new MetricsBucketToggle(
+                    new DefaultFeature('test', true, []),
+                    true,
+                    new DefaultVariant('test1', true),
+                )),
+        ];
+    }
+}


### PR DESCRIPTION
# Description

Instead of serializing the whole object to cache, a simple (and small) string which can be reconstructed to the metrics bucket object is serialized instead. Should massively lower the size of the metrics in the cache storage.

Fixes #197 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
