### PR TITLE
Feat: Allow basic parameters to be late bound

### DIFF
--- a/src/Configuration/UnleashConfiguration.php
+++ b/src/Configuration/UnleashConfiguration.php
@@ -5,6 +5,7 @@ namespace Unleash\Client\Configuration;
 use JetBrains\PhpStorm\Pure;
 use LogicException;
 use Psr\SimpleCache\CacheInterface;
+use Stringable;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Unleash\Client\Bootstrap\BootstrapHandler;
@@ -22,9 +23,9 @@ final class UnleashConfiguration
      * @param array<string,string> $headers
      */
     public function __construct(
-        private string $url,
-        private string $appName,
-        private string $instanceId,
+        private string|Stringable $url,
+        private string|Stringable $appName,
+        private string|Stringable $instanceId,
         private ?CacheInterface $cache = null,
         private int $ttl = 30,
         private int $metricsInterval = 30_000,
@@ -71,7 +72,7 @@ final class UnleashConfiguration
             $url .= '/';
         }
 
-        return $url;
+        return (string) $url;
     }
 
     public function getAppName(): string
@@ -146,21 +147,21 @@ final class UnleashConfiguration
         return $this->metricsEnabled;
     }
 
-    public function setUrl(string $url): self
+    public function setUrl(string|Stringable $url): self
     {
         $this->url = $url;
 
         return $this;
     }
 
-    public function setAppName(string $appName): self
+    public function setAppName(string|Stringable $appName): self
     {
         $this->appName = $appName;
 
         return $this;
     }
 
-    public function setInstanceId(string $instanceId): self
+    public function setInstanceId(string|Stringable $instanceId): self
     {
         $this->instanceId = $instanceId;
 

--- a/tests/Configuration/UnleashConfigurationTest.php
+++ b/tests/Configuration/UnleashConfigurationTest.php
@@ -118,19 +118,24 @@ final class UnleashConfigurationTest extends TestCase
         $realAppName = 'TestApp';
         $realInstanceId = '123';
 
-        $shadowed = fn (string &$value) => new class($value) {
-            private string $realUrl;
+        $shadowed = function (string &$value) {
+            return new class($value) {
+                /**
+                 * @var string
+                 */
+                private $realUrl;
 
-            public function __construct(
-                string &$realUrl,
-            ) {
-                $this->realUrl = &$realUrl;
-            }
+                public function __construct(
+                    string &$realUrl,
+                ) {
+                    $this->realUrl = &$realUrl;
+                }
 
-            public function __toString(): string
-            {
-                return $this->realUrl;
-            }
+                public function __toString(): string
+                {
+                    return $this->realUrl;
+                }
+            };
         };
 
         $url = $shadowed($realUrl);

--- a/tests/Configuration/UnleashConfigurationTest.php
+++ b/tests/Configuration/UnleashConfigurationTest.php
@@ -111,4 +111,43 @@ final class UnleashConfigurationTest extends TestCase
         $resolvedMetricsUrl = $proxyInstance->getMetricsUrl();
         self::assertSame($resolvedMetricsUrl, 'http://localhost:3063/api/frontend/client/metrics');
     }
+
+    public function testStringable()
+    {
+        $realUrl = 'http://localhost:3063/api/';
+        $realAppName = 'TestApp';
+        $realInstanceId = '123';
+
+        $shadowed = fn (string &$value) => new class($value) {
+            private string $realUrl;
+
+            public function __construct(
+                string &$realUrl,
+            ) {
+                $this->realUrl = &$realUrl;
+            }
+
+            public function __toString(): string
+            {
+                return $this->realUrl;
+            }
+        };
+
+        $url = $shadowed($realUrl);
+        $appName = $shadowed($realAppName);
+        $instanceId = $shadowed($realInstanceId);
+
+        $instance = new UnleashConfiguration($url, $appName, $instanceId);
+        self::assertSame($realUrl, (string) $instance->getUrl());
+        self::assertSame($realAppName, (string) $instance->getAppName());
+        self::assertSame($realInstanceId, (string) $instance->getInstanceId());
+
+        $realUrl = 'http://localhost:3063/api/v2/';
+        $realAppName = 'TestApp2';
+        $realInstanceId = '456';
+
+        self::assertSame($realUrl, (string) $instance->getUrl());
+        self::assertSame($realAppName, (string) $instance->getAppName());
+        self::assertSame($realInstanceId, (string) $instance->getInstanceId());
+    }
 }

--- a/tests/Configuration/UnleashConfigurationTest.php
+++ b/tests/Configuration/UnleashConfigurationTest.php
@@ -126,7 +126,7 @@ final class UnleashConfigurationTest extends TestCase
                 private $realUrl;
 
                 public function __construct(
-                    string &$realUrl,
+                    string &$realUrl
                 ) {
                     $this->realUrl = &$realUrl;
                 }


### PR DESCRIPTION
# Description

This PR allows the three mandatory parameters to be passed as `Stringable` objects. Those can be used anywhere a string is expected. The advantage is that the `__toString()` can be resolved at the time of casting to whatever is necessary, like dynamic environment variable.

Relates to https://github.com/Unleash/unleash-client-symfony/issues/66

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
