### PR TITLE
Chore: Specify php version for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,10 @@ jobs:
     name: Release latest PHP version
     runs-on: ubuntu-latest
     steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
       - name: Extract Version Name
         id: extract_name
         uses: actions/github-script@v7


### PR DESCRIPTION
# Description

Specifies a PHP version for the release script, the release would currently fail because the default version on GitHub actions is apparently lower than 8.3.
