### PR TITLE
Feat: Add possibility to refresh Cache, regardless of TTL

### DIFF
--- a/src/Repository/UnleashRepository.php
+++ b/src/Repository/UnleashRepository.php
@@ -4,6 +4,9 @@ namespace Unleash\Client\Repository;
 
 use Unleash\Client\DTO\Feature;
 
+/**
+ * @method void refreshCache()
+ */
 interface UnleashRepository
 {
     public function findFeature(string $featureName): ?Feature;

--- a/tests/Repository/DefaultUnleashRepositoryTest.php
+++ b/tests/Repository/DefaultUnleashRepositoryTest.php
@@ -168,6 +168,32 @@ final class DefaultUnleashRepositoryTest extends AbstractHttpClientTestCase
         self::assertNull($repository->findFeature('test'));
     }
 
+    public function testRefreshCache()
+    {
+        $cache = $this->getRealCache();
+        $repository = new DefaultUnleashRepository(
+            $this->httpClient,
+            new HttpFactory(),
+            (new UnleashConfiguration('', '', ''))
+                ->setCache($cache)
+                ->setTtl(5)
+        );
+
+        $this->pushResponse($this->response, 3);
+        $repository->getFeatures();
+
+        sleep(3);
+        $repository->refreshCache();
+        sleep(3);
+
+        self::assertCount(2, $this->requestHistory);
+
+        //Cache entry should have been invalidated by now (3+3 > TTL) if we didn't refresh it
+        $repository->getFeatures();
+        //Cache was hit if we have no new requests
+        self::assertCount(2, $this->requestHistory);
+    }
+
     public function testCustomHeaders()
     {
         $this->pushResponse($this->response);


### PR DESCRIPTION
# Description

This pull request introduces a new refreshCache functionality, designed to proactively refresh specific cached items before their TTL (time-to-live) expires. This enhancement ensures that our application maintains up-to-date data in the cache, minimizing the likelihood of cache misses.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
