### PR TITLE
Fix: race condition in caching layer

### DIFF
--- a/src/Repository/DefaultUnleashRepository.php
+++ b/src/Repository/DefaultUnleashRepository.php
@@ -140,11 +140,10 @@ final readonly class DefaultUnleashRepository implements UnleashRepository
     {
         $cache = $this->configuration->getCache();
 
-        if (!$cache->has(CacheKey::FEATURES)) {
+        $result = $cache->get(CacheKey::FEATURES);
+        if ($result === null) {
             return null;
         }
-
-        $result = $cache->get(CacheKey::FEATURES, []);
         assert(is_array($result));
 
         return $result;


### PR DESCRIPTION
# Description

This fixes a bit of a subtle bug in the caching layer where the SDK can start to return empty sets of flags if the cache is invalidated between checking the cache status and doing the actual retrieve. This forces the read from cache to be atomic.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Custom script - spin up 50 processes each running their own SDK, backed by Redis all checking a feature that should always be enabled. This typically produces a false result in 10-20 seconds. Apply fix rerun script for 20 minutes.

- [x] Integration tests / Manual Tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
