### PR TITLE
Chore: Add an example for http timeout

### DIFF
--- a/examples/10-timeout.php
+++ b/examples/10-timeout.php
@@ -1,0 +1,30 @@
+<?php
+
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\Psr18Client;
+use Unleash\Client\UnleashBuilder;
+
+require __DIR__ . '/_common.php';
+
+if (class_exists(Client::class)) {
+    $httpClient = new Client([
+        RequestOptions::TIMEOUT => 2,
+    ]);
+} else if (class_exists(Psr18Client::class)) {
+    $httpClient = HttpClient::create([
+        'timeout' => 2,
+    ]);
+    $httpClient = new Psr18Client($httpClient);
+} else {
+    throw new LogicException('No supported http client (for this example) found');
+}
+
+$unleash = UnleashBuilder::create()
+    ->withAppName($appName)
+    ->withAppUrl($appUrl)
+    ->withInstanceId($instanceId)
+    ->withHttpClient($httpClient)
+    ->build()
+;

--- a/examples/10-timeout.php
+++ b/examples/10-timeout.php
@@ -26,5 +26,12 @@ $unleash = UnleashBuilder::create()
     ->withAppUrl($appUrl)
     ->withInstanceId($instanceId)
     ->withHttpClient($httpClient)
+    ->withHeader('Authorization', $apiKey)
     ->build()
 ;
+
+if ($unleash->isEnabled('myFeature')) {
+    echo "myFeature is enabled";
+} else {
+    echo "myFeature is disabled";
+}


### PR DESCRIPTION
# Description

Adds an example on how to add a http client timeout for the two most popular http clients.

Fixes #220 

# Checklist:

- [x] I have performed a self-review of my own code
