### PR TITLE
feat: add extended metrics metadata

### DIFF
--- a/src/Client/DefaultRegistrationService.php
+++ b/src/Client/DefaultRegistrationService.php
@@ -58,7 +58,7 @@ final class DefaultRegistrationService implements RegistrationService
                 'started' => (new DateTimeImmutable())->format('c'),
                 'interval' => $this->configuration->getMetricsInterval(),
                 'platformName' => PHP_SAPI,
-                'platformVersion' => phpversion(),
+                'platformVersion' => PHP_VERSION,
                 'yggdrasilVersion' => null,
                 'specVersion' => Unleash::SPECIFICATION_VERSION,
             ], JSON_THROW_ON_ERROR)));

--- a/src/Client/DefaultRegistrationService.php
+++ b/src/Client/DefaultRegistrationService.php
@@ -57,6 +57,10 @@ final class DefaultRegistrationService implements RegistrationService
                 'strategies' => array_map(fn (StrategyHandler $strategyHandler): string => $strategyHandler->getStrategyName(), $strategyHandlers),
                 'started' => (new DateTimeImmutable())->format('c'),
                 'interval' => $this->configuration->getMetricsInterval(),
+                'platformName' => PHP_SAPI,
+                'platformVersion' => phpversion(),
+                'yggdrasilVersion' => null,
+                'specVersion' => Unleash::SPECIFICATION_VERSION,
             ], JSON_THROW_ON_ERROR)));
         foreach ($this->configuration->getHeaders() as $name => $value) {
             $request = $request->withHeader($name, $value);

--- a/src/Metrics/DefaultMetricsSender.php
+++ b/src/Metrics/DefaultMetricsSender.php
@@ -34,7 +34,7 @@ final readonly class DefaultMetricsSender implements MetricsSender
                 'instanceId' => $this->configuration->getInstanceId(),
                 'bucket' => $bucket->jsonSerialize(),
                 'platformName' => PHP_SAPI,
-                'platformVersion' => phpversion(),
+                'platformVersion' => PHP_VERSION,
                 'yggdrasilVersion' => null,
                 'specVersion' => Unleash::SPECIFICATION_VERSION,
             ], JSON_THROW_ON_ERROR)));

--- a/src/Metrics/DefaultMetricsSender.php
+++ b/src/Metrics/DefaultMetricsSender.php
@@ -8,6 +8,7 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Unleash\Client\Configuration\UnleashConfiguration;
 use Unleash\Client\Helper\StringStream;
+use Unleash\Client\Unleash;
 
 final readonly class DefaultMetricsSender implements MetricsSender
 {
@@ -32,6 +33,10 @@ final readonly class DefaultMetricsSender implements MetricsSender
                 'appName' => $this->configuration->getAppName(),
                 'instanceId' => $this->configuration->getInstanceId(),
                 'bucket' => $bucket->jsonSerialize(),
+                'platformName' => PHP_SAPI,
+                'platformVersion' => phpversion(),
+                'yggdrasilVersion' => null,
+                'specVersion' => Unleash::SPECIFICATION_VERSION,
             ], JSON_THROW_ON_ERROR)));
         foreach ($this->configuration->getHeaders() as $name => $value) {
             $request = $request->withHeader($name, $value);

--- a/src/Repository/DefaultUnleashRepository.php
+++ b/src/Repository/DefaultUnleashRepository.php
@@ -34,6 +34,7 @@ use Unleash\Client\Event\UnleashEvents;
 use Unleash\Client\Exception\HttpResponseException;
 use Unleash\Client\Exception\InvalidValueException;
 use Unleash\Client\Helper\Url;
+use Unleash\Client\Unleash;
 
 /**
  * @phpstan-type ConstraintArray array{
@@ -511,7 +512,7 @@ final readonly class DefaultUnleashRepository implements UnleashRepository
                 ->createRequest('GET', (string) Url::appendPath($this->configuration->getUrl(), 'client/features'))
                 ->withHeader('UNLEASH-APPNAME', $this->configuration->getAppName())
                 ->withHeader('UNLEASH-INSTANCEID', $this->configuration->getInstanceId())
-                ->withHeader('Unleash-Client-Spec', '4.3.2');
+                ->withHeader('Unleash-Client-Spec', Unleash::SPECIFICATION_VERSION);
 
             foreach ($this->configuration->getHeaders() as $name => $value) {
                 $request = $request->withHeader($name, $value);

--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -9,6 +9,8 @@ interface Unleash
 {
     public const string SDK_VERSION = '2.5.1';
 
+    public const string SPECIFICATION_VERSION = '4.3.2';
+
     public function isEnabled(string $featureName, ?Context $context = null, bool $default = false): bool;
 
     public function getVariant(string $featureName, ?Context $context = null, ?Variant $fallbackVariant = null): Variant;


### PR DESCRIPTION
# Description

Adds extended metrics/registration metadata. This doesn't make any changes in terms of public API or behavior, but allows the Unleash server better insight into SDKs running in the wild. 

Yggdrasil version is currently defaulted to null. Yggdrasil is long term plans, which may never make it into this project

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

We don't really test against any of the metrics/registration data in this SDK (probably sane). So I've opted just to plug this into Unleash and observe the incoming data

- [x] Integration tests / Manual Tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
