### PR TITLE
Chore/bump client spec version

### DIFF
--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -9,7 +9,7 @@ interface Unleash
 {
     public const string SDK_VERSION = '2.5.1';
 
-    public const string SPECIFICATION_VERSION = '4.3.2';
+    public const string SPECIFICATION_VERSION = '5.0.2';
 
     public function isEnabled(string $featureName, ?Context $context = null, bool $default = false): bool;
 


### PR DESCRIPTION
Moves the version of the client specification that's advertised to Unleash to 5.0.2 in order to match the version that this SDK is actually tested against.

@RikudouSage this is probably a cheap patch to get the versions matching again but ideally the version would always match and be enforced at build time. Most of the other SDKs now just clone a shallow snapshot of the repo to the tag that matches the source code when it's being run in CI. Are you deeply attached to using a submodule for the client spec because forcing the versions to match isn't quite as easy with the submodule