### PR TITLE
fix: support both snake_case and camelCase versions of impression data

### DIFF
--- a/src/DTO/DefaultProxyFeature.php
+++ b/src/DTO/DefaultProxyFeature.php
@@ -28,6 +28,7 @@ final readonly class DefaultProxyFeature implements ProxyFeature, JsonSerializab
      *             value: string
      *         }
      *     },
+     *     impression_data: bool,
      *     impressionData: bool
      * } $response
      */
@@ -37,7 +38,9 @@ final readonly class DefaultProxyFeature implements ProxyFeature, JsonSerializab
         // tries to new this up manually and isn't interesting to tests
 
         // @codeCoverageIgnoreStart
-        assert(isset($response['name'], $response['enabled'], $response['variant'], $response['impressionData']));
+        assert(isset($response['name'], $response['enabled'], $response['variant']) 
+            && (isset($response['impressionData']) || isset($response['impression_data']))
+        );
         // @codeCoverageIgnoreEnd
 
         $this->name = $response['name'];

--- a/src/DTO/DefaultProxyFeature.php
+++ b/src/DTO/DefaultProxyFeature.php
@@ -28,7 +28,7 @@ final readonly class DefaultProxyFeature implements ProxyFeature, JsonSerializab
      *             value: string
      *         }
      *     },
-     *     impression_data: bool
+     *     impressionData: bool
      * } $response
      */
     public function __construct(array $response)
@@ -37,12 +37,12 @@ final readonly class DefaultProxyFeature implements ProxyFeature, JsonSerializab
         // tries to new this up manually and isn't interesting to tests
 
         // @codeCoverageIgnoreStart
-        assert(isset($response['name'], $response['enabled'], $response['variant'], $response['impression_data']));
+        assert(isset($response['name'], $response['enabled'], $response['variant'], $response['impressionData']));
         // @codeCoverageIgnoreEnd
 
         $this->name = $response['name'];
         $this->enabled = $response['enabled'];
-        $this->impressionData = $response['impression_data'];
+        $this->impressionData = $response['impressionData'] ?? $response['impression_data'];
 
         $payload = null;
 
@@ -88,6 +88,7 @@ final readonly class DefaultProxyFeature implements ProxyFeature, JsonSerializab
             'enabled' => $this->enabled,
             'variant' => $this->variant,
             'impression_data' => $this->impressionData,
+            'impressionData' => $this->impressionData, // maybe we don't need this
         ];
     }
 }

--- a/src/DTO/DefaultProxyFeature.php
+++ b/src/DTO/DefaultProxyFeature.php
@@ -38,7 +38,8 @@ final readonly class DefaultProxyFeature implements ProxyFeature, JsonSerializab
         // tries to new this up manually and isn't interesting to tests
 
         // @codeCoverageIgnoreStart
-        assert(isset($response['name'], $response['enabled'], $response['variant']) 
+        assert(
+            isset($response['name'], $response['enabled'], $response['variant'])
             && (isset($response['impressionData']) || isset($response['impression_data']))
         );
         // @codeCoverageIgnoreEnd

--- a/src/DTO/DefaultProxyFeature.php
+++ b/src/DTO/DefaultProxyFeature.php
@@ -28,8 +28,7 @@ final readonly class DefaultProxyFeature implements ProxyFeature, JsonSerializab
      *             value: string
      *         }
      *     },
-     *     impression_data?: bool,
-     *     impressionData?: bool
+     *     impressionData: bool
      * } $response
      */
     public function __construct(array $response)
@@ -46,7 +45,7 @@ final readonly class DefaultProxyFeature implements ProxyFeature, JsonSerializab
 
         $this->name = $response['name'];
         $this->enabled = $response['enabled'];
-        $this->impressionData = $response['impressionData'] ?? $response['impression_data'];
+        $this->impressionData = $response['impressionData'] ?? $response['impression_data'] ?? false;
 
         $payload = null;
 

--- a/src/DTO/DefaultProxyFeature.php
+++ b/src/DTO/DefaultProxyFeature.php
@@ -28,8 +28,8 @@ final readonly class DefaultProxyFeature implements ProxyFeature, JsonSerializab
      *             value: string
      *         }
      *     },
-     *     impression_data: bool,
-     *     impressionData: bool
+     *     impression_data?: bool,
+     *     impressionData?: bool
      * } $response
      */
     public function __construct(array $response)

--- a/src/DTO/DefaultProxyFeature.php
+++ b/src/DTO/DefaultProxyFeature.php
@@ -91,8 +91,8 @@ final readonly class DefaultProxyFeature implements ProxyFeature, JsonSerializab
             'name' => $this->name,
             'enabled' => $this->enabled,
             'variant' => $this->variant,
-            'impression_data' => $this->impressionData,
-            'impressionData' => $this->impressionData, // maybe we don't need this
+            'impression_data' => $this->impressionData, // deprecated
+            'impressionData' => $this->impressionData, // if you were reading the snake then you should read the camel
         ];
     }
 }

--- a/src/Repository/DefaultUnleashProxyRepository.php
+++ b/src/Repository/DefaultUnleashProxyRepository.php
@@ -153,7 +153,7 @@ final readonly class DefaultUnleashProxyRepository implements ProxyRepository
      *             value: string
      *         }
      *     },
-     *     impression_data?: bool
+     *     impression_data?: bool,
      *     impressionData?: bool
      * }|null
      */

--- a/src/Repository/DefaultUnleashProxyRepository.php
+++ b/src/Repository/DefaultUnleashProxyRepository.php
@@ -158,7 +158,7 @@ final readonly class DefaultUnleashProxyRepository implements ProxyRepository
      */
     private function validateResponse(array $response): ?array
     {
-        if (!isset($response['name'], $response['enabled'], $response['variant'], $response['impressionData'])) {
+        if (!isset($response['name'], $response['enabled'], $response['variant']) && !(isset($response['impressionData']) || isset($response['impression_data']))) {
             return null;
         }
 

--- a/src/Repository/DefaultUnleashProxyRepository.php
+++ b/src/Repository/DefaultUnleashProxyRepository.php
@@ -163,7 +163,8 @@ final readonly class DefaultUnleashProxyRepository implements ProxyRepository
             return null;
         }
 
-        if (!is_string($response['name']) || !is_bool($response['enabled']) || !is_bool($response['impressionData']) || !is_array($response['variant'])) {
+        $impressionData = $response['impressionData'] ?? $response['impression_data'] ?? false;
+        if (!is_string($response['name']) || !is_bool($response['enabled']) || !is_bool($impressionData) || !is_array($response['variant'])) {
             return null;
         }
 

--- a/src/Repository/DefaultUnleashProxyRepository.php
+++ b/src/Repository/DefaultUnleashProxyRepository.php
@@ -153,16 +153,16 @@ final readonly class DefaultUnleashProxyRepository implements ProxyRepository
      *             value: string
      *         }
      *     },
-     *     impression_data: bool
+     *     impressionData: bool
      * }|null
      */
     private function validateResponse(array $response): ?array
     {
-        if (!isset($response['name'], $response['enabled'], $response['variant'], $response['impression_data'])) {
+        if (!isset($response['name'], $response['enabled'], $response['variant'], $response['impressionData'])) {
             return null;
         }
 
-        if (!is_string($response['name']) || !is_bool($response['enabled']) || !is_bool($response['impression_data']) || !is_array($response['variant'])) {
+        if (!is_string($response['name']) || !is_bool($response['enabled']) || !is_bool($response['impressionData']) || !is_array($response['variant'])) {
             return null;
         }
 

--- a/src/Repository/DefaultUnleashProxyRepository.php
+++ b/src/Repository/DefaultUnleashProxyRepository.php
@@ -153,7 +153,8 @@ final readonly class DefaultUnleashProxyRepository implements ProxyRepository
      *             value: string
      *         }
      *     },
-     *     impressionData: bool
+     *     impression_data?: bool
+     *     impressionData?: bool
      * }|null
      */
     private function validateResponse(array $response): ?array

--- a/src/Repository/DefaultUnleashProxyRepository.php
+++ b/src/Repository/DefaultUnleashProxyRepository.php
@@ -153,18 +153,21 @@ final readonly class DefaultUnleashProxyRepository implements ProxyRepository
      *             value: string
      *         }
      *     },
-     *     impression_data?: bool,
-     *     impressionData?: bool
+     *     impressionData: bool
      * }|null
      */
     private function validateResponse(array $response): ?array
     {
-        if (!isset($response['name'], $response['enabled'], $response['variant']) && !(isset($response['impressionData']) || isset($response['impression_data']))) {
+        // fix impression data:
+        if (isset($response['impression_data'])) {
+            $response['impressionData'] = $response['impression_data'];
+            unset($response['impression_data']);
+        }
+        if (!isset($response['name'], $response['enabled'], $response['variant'], $response['impressionData'])) {
             return null;
         }
 
-        $impressionData = $response['impressionData'] ?? $response['impression_data'] ?? false;
-        if (!is_string($response['name']) || !is_bool($response['enabled']) || !is_bool($impressionData) || !is_array($response['variant'])) {
+        if (!is_string($response['name']) || !is_bool($response['enabled']) || !is_bool($response['impressionData']) || !is_array($response['variant'])) {
             return null;
         }
 

--- a/tests/Bootstrap/FileBootstrapProviderTest.php
+++ b/tests/Bootstrap/FileBootstrapProviderTest.php
@@ -75,7 +75,7 @@ final class FileBootstrapProviderTest extends TestCase
         $file = $this->createTemporaryFile();
         chmod($file, 0222);
         $instance = new FileBootstrapProvider($file);
-        $this->expectException(JsonException::class);
+        $this->expectException(RuntimeException::class);
         $instance->getBootstrap();
     }
 }

--- a/tests/Bootstrap/FileBootstrapProviderTest.php
+++ b/tests/Bootstrap/FileBootstrapProviderTest.php
@@ -75,7 +75,7 @@ final class FileBootstrapProviderTest extends TestCase
         $file = $this->createTemporaryFile();
         chmod($file, 0222);
         $instance = new FileBootstrapProvider($file);
-        $this->expectException(RuntimeException::class);
+        $this->expectException(JsonException::class);
         $instance->getBootstrap();
     }
 }

--- a/tests/DTO/DefaultProxyFeatureTest.php
+++ b/tests/DTO/DefaultProxyFeatureTest.php
@@ -26,6 +26,6 @@ final class DefaultProxyFeatureTest extends TestCase
     {
         $instance = new DefaultProxyFeature(['name' => 'test', 'enabled' => true, 'impressionData' => true, 'variant' => ['name' => 'someVariant', 'enabled' => true, 'payload' => ['type' => 'string', 'value' => 'test']]]);
         $json = json_encode($instance);
-        self::assertEquals('{"name":"test","enabled":true,"variant":{"name":"someVariant","enabled":true,"payload":{"type":"string","value":"test"}},"impressionData":true}', $json);
+        self::assertEquals('{"name":"test","enabled":true,"variant":{"name":"someVariant","enabled":true,"payload":{"type":"string","value":"test"}},"impression_data":true,"impressionData":true}', $json);
     }
 }

--- a/tests/DTO/DefaultProxyFeatureTest.php
+++ b/tests/DTO/DefaultProxyFeatureTest.php
@@ -22,9 +22,30 @@ final class DefaultProxyFeatureTest extends TestCase
         self::assertEquals('someVariant', $instance->getVariant()->getName());
     }
 
+    public function testGetPropertiesImpressionDataSnakeCaseBackwardsCompatibility()
+    {
+        $instance = new DefaultProxyFeature(['name' => 'test', 'enabled' => true, 'impression_data' => true, 'variant' => ['name' => 'someVariant', 'enabled' => true, 'payload' => ['type' => 'string', 'value' => 'test']]]);
+        self::assertIsString($instance->getName());
+        self::assertIsBool($instance->isEnabled());
+        self::assertIsBool($instance->hasImpressionData());
+        self::assertInstanceOf(DefaultVariant::class, $instance->getVariant());
+
+        self::assertEquals('test', $instance->getName());
+        self::assertTrue($instance->isEnabled());
+        self::assertTrue($instance->hasImpressionData());
+        self::assertEquals('someVariant', $instance->getVariant()->getName());
+    }
+
     public function testToJson()
     {
         $instance = new DefaultProxyFeature(['name' => 'test', 'enabled' => true, 'impressionData' => true, 'variant' => ['name' => 'someVariant', 'enabled' => true, 'payload' => ['type' => 'string', 'value' => 'test']]]);
+        $json = json_encode($instance);
+        self::assertEquals('{"name":"test","enabled":true,"variant":{"name":"someVariant","enabled":true,"payload":{"type":"string","value":"test"}},"impression_data":true,"impressionData":true}', $json);
+    }
+
+    public function testToJsonFromSnakeCaseImpressionDataForBackwardsCompatibility()
+    {
+        $instance = new DefaultProxyFeature(['name' => 'test', 'enabled' => true, 'impression_data' => true, 'variant' => ['name' => 'someVariant', 'enabled' => true, 'payload' => ['type' => 'string', 'value' => 'test']]]);
         $json = json_encode($instance);
         self::assertEquals('{"name":"test","enabled":true,"variant":{"name":"someVariant","enabled":true,"payload":{"type":"string","value":"test"}},"impression_data":true,"impressionData":true}', $json);
     }

--- a/tests/DTO/DefaultProxyFeatureTest.php
+++ b/tests/DTO/DefaultProxyFeatureTest.php
@@ -10,7 +10,7 @@ final class DefaultProxyFeatureTest extends TestCase
 {
     public function testGetProperties()
     {
-        $instance = new DefaultProxyFeature(['name' => 'test', 'enabled' => true, 'impression_data' => true, 'variant' => ['name' => 'someVariant', 'enabled' => true, 'payload' => ['type' => 'string', 'value' => 'test']]]);
+        $instance = new DefaultProxyFeature(['name' => 'test', 'enabled' => true, 'impressionData' => true, 'variant' => ['name' => 'someVariant', 'enabled' => true, 'payload' => ['type' => 'string', 'value' => 'test']]]);
         self::assertIsString($instance->getName());
         self::assertIsBool($instance->isEnabled());
         self::assertIsBool($instance->hasImpressionData());
@@ -24,8 +24,8 @@ final class DefaultProxyFeatureTest extends TestCase
 
     public function testToJson()
     {
-        $instance = new DefaultProxyFeature(['name' => 'test', 'enabled' => true, 'impression_data' => true, 'variant' => ['name' => 'someVariant', 'enabled' => true, 'payload' => ['type' => 'string', 'value' => 'test']]]);
+        $instance = new DefaultProxyFeature(['name' => 'test', 'enabled' => true, 'impressionData' => true, 'variant' => ['name' => 'someVariant', 'enabled' => true, 'payload' => ['type' => 'string', 'value' => 'test']]]);
         $json = json_encode($instance);
-        self::assertEquals('{"name":"test","enabled":true,"variant":{"name":"someVariant","enabled":true,"payload":{"type":"string","value":"test"}},"impression_data":true}', $json);
+        self::assertEquals('{"name":"test","enabled":true,"variant":{"name":"someVariant","enabled":true,"payload":{"type":"string","value":"test"}},"impressionData":true}', $json);
     }
 }

--- a/tests/DefaultProxyUnleashTest.php
+++ b/tests/DefaultProxyUnleashTest.php
@@ -36,7 +36,7 @@ final class DefaultProxyUnleashTest extends AbstractHttpClientTestCase
                 'name' => 'some-variant',
                 'enabled' => true,
             ],
-            'impression_data' => false,
+            'impressionData' => false,
         ]);
         $unleash = $builder->build();
 
@@ -89,7 +89,7 @@ final class DefaultProxyUnleashTest extends AbstractHttpClientTestCase
                 ],
                 'enabled' => true,
             ],
-            'impression_data' => false,
+            'impressionData' => false,
         ]);
         $unleash = $builder->build();
         $variant = $unleash->getVariant('test');
@@ -107,7 +107,7 @@ final class DefaultProxyUnleashTest extends AbstractHttpClientTestCase
                 'name' => 'some-variant',
                 'enabled' => true,
             ],
-            'impression_data' => false,
+            'impressionData' => false,
         ]);
         $unleash = $builder->build();
         $variant = $unleash->getVariant('test');
@@ -138,7 +138,7 @@ final class DefaultProxyUnleashTest extends AbstractHttpClientTestCase
                 'payload' => null,
                 'enabled' => true,
             ],
-            'impression_data' => false,
+            'impressionData' => false,
         ]);
         $unleash = $builder->build();
         $variant = $unleash->getVariant('test');
@@ -159,7 +159,7 @@ final class DefaultProxyUnleashTest extends AbstractHttpClientTestCase
                 'name' => 'some-variant',
                 'enabled' => true,
             ],
-            'impression_data' => false,
+            'impressionData' => false,
         ]);
 
         $builder = new TestBuilder();
@@ -236,7 +236,7 @@ final class DefaultProxyUnleashTest extends AbstractHttpClientTestCase
                     'name' => 'some-variant',
                     'enabled' => true,
                 ],
-                'impression_data' => false,
+                'impressionData' => false,
             ],
             [
                 'name' => 'test',
@@ -244,7 +244,7 @@ final class DefaultProxyUnleashTest extends AbstractHttpClientTestCase
                 'variant' => [
                     'poisoned' => 'variant',
                 ],
-                'impression_data' => false,
+                'impressionData' => false,
             ],
             [
                 'name' => 'test',
@@ -257,7 +257,7 @@ final class DefaultProxyUnleashTest extends AbstractHttpClientTestCase
                         'value' => 'stuff',
                     ],
                 ],
-                'impression_data' => false,
+                'impressionData' => false,
             ],
         ];
 

--- a/tests/Repository/DefaultUnleashProxyRepositoryTest.php
+++ b/tests/Repository/DefaultUnleashProxyRepositoryTest.php
@@ -71,7 +71,7 @@ final class DefaultUnleashProxyRepositoryTest extends AbstractHttpClientTestCase
                         ],
                         'enabled' => true,
                     ],
-                    'impression_data' => false,
+                    'impressionData' => false,
                 ])
             ),
         ]);
@@ -112,7 +112,7 @@ final class DefaultUnleashProxyRepositoryTest extends AbstractHttpClientTestCase
                 ],
                 'enabled' => true,
             ],
-            'impression_data' => false,
+            'impressionData' => false,
         ]);
 
         $mock = new MockHandler([

--- a/tests/Repository/DefaultUnleashProxyRepositoryWithSnakeCaseImpressionDataTest.php
+++ b/tests/Repository/DefaultUnleashProxyRepositoryWithSnakeCaseImpressionDataTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Unleash\Client\Tests\Repository;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\HttpFactory;
+use GuzzleHttp\Psr7\Response;
+use Unleash\Client\Configuration\UnleashConfiguration;
+use Unleash\Client\DTO\DefaultVariant;
+use Unleash\Client\DTO\DefaultVariantPayload;
+use Unleash\Client\Enum\Stickiness;
+use Unleash\Client\Helper\Url;
+use Unleash\Client\Repository\DefaultUnleashProxyRepository;
+use Unleash\Client\Tests\AbstractHttpClientTestCase;
+use Unleash\Client\Tests\Traits\FakeCacheImplementationTrait;
+use Unleash\Client\Tests\Traits\RealCacheImplementationTrait;
+
+// this tests backward compatibility with a buggy old version of Unleash Edge
+final class DefaultUnleashProxyRepositoryWithSnakeCaseImpressionDataTest extends AbstractHttpClientTestCase
+{
+    use FakeCacheImplementationTrait, RealCacheImplementationTrait {
+        FakeCacheImplementationTrait::getCache insteadof RealCacheImplementationTrait;
+
+        RealCacheImplementationTrait::getCache as getRealCache;
+    }
+
+    public function testNon200ResponseDegradesGracefully()
+    {
+        $container = [];
+        $history = Middleware::history($container);
+
+        $mock = new MockHandler([
+            new Response(400, [], 'Error, bad request'),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $handlerStack->push($history);
+
+        $client = new Client(['handler' => $handlerStack]);
+        $config = (new UnleashConfiguration('', '', ''))
+            ->setCache($this->getCache())
+            ->setProxyKey('some-key')
+            ->setTtl(5);
+
+        $requestFactory = new HttpFactory();
+
+        $repository = new DefaultUnleashProxyRepository($config, $client, $requestFactory);
+        $resolvedFeature = $repository->findFeatureByContext('some-feature');
+        $this->assertNull($resolvedFeature);
+    }
+
+    public function test200ResponseResolvesCorrectly()
+    {
+        $container = [];
+        $history = Middleware::history($container);
+
+        $mock = new MockHandler([
+            new Response(
+                200,
+                ['ETag' => 'etag value'],
+                json_encode([
+                    'name' => 'test',
+                    'enabled' => true,
+                    'variant' => [
+                        'name' => 'some-variant',
+                        'payload' => [
+                            'type' => 'string',
+                            'value' => 'some-value',
+                        ],
+                        'enabled' => true,
+                    ],
+                    'impression_data' => false,
+                ])
+            ),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $handlerStack->push($history);
+
+        $client = new Client(['handler' => $handlerStack]);
+        $config = (new UnleashConfiguration('', '', ''))
+            ->setCache($this->getCache())
+            ->setProxyKey('some-key')
+            ->setTtl(5);
+
+        $requestFactory = new HttpFactory();
+
+        $repository = new DefaultUnleashProxyRepository($config, $client, $requestFactory);
+        $resolvedFeature = $repository->findFeatureByContext('test');
+
+        $expectedVariant = new DefaultVariant('some-variant', true, 0, Stickiness::DEFAULT, new DefaultVariantPayload('string', 'some-value'));
+
+        $this->assertEquals('test', $resolvedFeature->getName());
+        $this->assertTrue($resolvedFeature->isEnabled());
+        $this->assertEquals($expectedVariant, $resolvedFeature->getVariant());
+    }
+
+    public function testCacheTtlIsRespected()
+    {
+        $container = [];
+        $history = Middleware::history($container);
+        $response = json_encode([
+            'name' => 'test',
+            'enabled' => true,
+            'variant' => [
+                'name' => 'some-variant',
+                'payload' => [
+                    'type' => 'string',
+                    'value' => 'some-value',
+                ],
+                'enabled' => true,
+            ],
+            'impression_data' => false,
+        ]);
+
+        $mock = new MockHandler([
+            new Response(
+                200,
+                ['ETag' => 'etag value'],
+                $response
+            ),
+            new Response(
+                200,
+                ['ETag' => 'etag value'],
+                $response
+            ),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $handlerStack->push($history);
+
+        $client = new Client(['handler' => $handlerStack]);
+        $config = (new UnleashConfiguration('', '', ''))
+            ->setCache($this->getRealCache())
+            ->setProxyKey('some-key')
+            ->setTtl(1);
+
+        $requestFactory = new HttpFactory();
+        $repository = new DefaultUnleashProxyRepository($config, $client, $requestFactory);
+
+        $repository->findFeatureByContext('test');
+        //cache is still warm so this should fall back to that
+        $repository->findFeatureByContext('test');
+
+        sleep(1);
+
+        //ttl should have expired so this should trigger an API call
+        $repository->findFeatureByContext('test');
+
+        $this->assertCount(2, $container);
+    }
+
+    public function testUrl()
+    {
+        $configuration = (new UnleashConfiguration(
+            new Url('https://localhost/api', 'somePrefix'),
+            '',
+            ''
+        ))->setCache($this->getCache())->setProxyKey('test');
+        $instance = new DefaultUnleashProxyRepository($configuration, $this->httpClient, new HttpFactory());
+        $this->pushResponse([]);
+
+        $instance->findFeatureByContext('testFeature');
+        self::assertCount(1, $this->requestHistory);
+        self::assertSame('https://localhost/api/frontend/features/testFeature?namePrefix=somePrefix', (string) $this->requestHistory[0]['request']->getUri());
+    }
+}


### PR DESCRIPTION
# Description

Impression data should have always been camelCase in unleash-edge. It was not by accident, and the php sdk is using the snake_case version which prevents users from upgrading to newer versions of edge where impression_data was changed to camelCase.

Fixes #226

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit tests
- [x] Spec Tests
- [ ] Integration tests / Manual Tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
