### PR TITLE
Chore: Explicitly mark parameters as nullable

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -66,6 +66,7 @@ return (new PhpCsFixer\Config())
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,
         'normalize_index_brace' => true,
+        'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,

--- a/src/Metrics/DefaultMetricsHandler.php
+++ b/src/Metrics/DefaultMetricsHandler.php
@@ -18,7 +18,7 @@ final readonly class DefaultMetricsHandler implements MetricsHandler
     }
 
     #[Override]
-    public function handleMetrics(Feature $feature, bool $successful, Variant $variant = null): void
+    public function handleMetrics(Feature $feature, bool $successful, ?Variant $variant = null): void
     {
         if (!$this->configuration->isMetricsEnabled()) {
             return;

--- a/src/Metrics/MetricsHandler.php
+++ b/src/Metrics/MetricsHandler.php
@@ -7,5 +7,5 @@ use Unleash\Client\DTO\Variant;
 
 interface MetricsHandler
 {
-    public function handleMetrics(Feature $feature, bool $successful, Variant $variant = null): void;
+    public function handleMetrics(Feature $feature, bool $successful, ?Variant $variant = null): void;
 }

--- a/tests/AbstractHttpClientTestCase.php
+++ b/tests/AbstractHttpClientTestCase.php
@@ -92,7 +92,7 @@ abstract class AbstractHttpClientTestCase extends TestCase
         );
 
         $this->metricsHandler = new class implements MetricsHandler {
-            public function handleMetrics(Feature $feature, bool $successful, Variant $variant = null): void
+            public function handleMetrics(Feature $feature, bool $successful, ?Variant $variant = null): void
             {
             }
         };

--- a/tests/ClientSpecificationTest.php
+++ b/tests/ClientSpecificationTest.php
@@ -53,7 +53,7 @@ final class ClientSpecificationTest extends AbstractHttpClientTestCase
             $this->registrationService,
             $configuration,
             new class implements MetricsHandler {
-                public function handleMetrics(Feature $feature, bool $successful, Variant $variant = null): void
+                public function handleMetrics(Feature $feature, bool $successful, ?Variant $variant = null): void
                 {
                 }
             },

--- a/tests/Configuration/UnleashContextTest.php
+++ b/tests/Configuration/UnleashContextTest.php
@@ -185,7 +185,7 @@ final class UnleashContextTest extends AbstractHttpClientTestCase
                 ->setAutoRegistrationEnabled(false)
                 ->setCache($this->getCache()),
             new class implements MetricsHandler {
-                public function handleMetrics(Feature $feature, bool $successful, Variant $variant = null): void
+                public function handleMetrics(Feature $feature, bool $successful, ?Variant $variant = null): void
                 {
                 }
             },

--- a/tests/ConstraintValidator/Operator/AbstractOperatorValidatorTest.php
+++ b/tests/ConstraintValidator/Operator/AbstractOperatorValidatorTest.php
@@ -53,7 +53,7 @@ final class AbstractOperatorValidatorTest extends AbstractHttpClientTestCase
                 ->setMetricsEnabled(false)
                 ->setAutoRegistrationEnabled(false),
             new class implements MetricsHandler {
-                public function handleMetrics(Feature $feature, bool $successful, Variant $variant = null): void
+                public function handleMetrics(Feature $feature, bool $successful, ?Variant $variant = null): void
                 {
                 }
             },

--- a/tests/TestHelpers/DependencyContainer/CacheAwareMetricsHandler.php
+++ b/tests/TestHelpers/DependencyContainer/CacheAwareMetricsHandler.php
@@ -20,7 +20,7 @@ final class CacheAwareMetricsHandler implements MetricsHandler, CacheAware
         $this->cache = $cache;
     }
 
-    public function handleMetrics(Feature $feature, bool $successful, Variant $variant = null): void
+    public function handleMetrics(Feature $feature, bool $successful, ?Variant $variant = null): void
     {
     }
 }

--- a/tests/TestHelpers/DependencyContainer/ConfigurationAwareMetricsHandler.php
+++ b/tests/TestHelpers/DependencyContainer/ConfigurationAwareMetricsHandler.php
@@ -20,7 +20,7 @@ final class ConfigurationAwareMetricsHandler implements MetricsHandler, Configur
         $this->configuration = $configuration;
     }
 
-    public function handleMetrics(Feature $feature, bool $successful, Variant $variant = null): void
+    public function handleMetrics(Feature $feature, bool $successful, ?Variant $variant = null): void
     {
     }
 }

--- a/tests/TestHelpers/DependencyContainer/MetricsSenderAwareMetricsHandler.php
+++ b/tests/TestHelpers/DependencyContainer/MetricsSenderAwareMetricsHandler.php
@@ -15,7 +15,7 @@ final class MetricsSenderAwareMetricsHandler implements MetricsHandler, MetricsS
      */
     public $metricsSender = null;
 
-    public function handleMetrics(Feature $feature, bool $successful, Variant $variant = null): void
+    public function handleMetrics(Feature $feature, bool $successful, ?Variant $variant = null): void
     {
     }
 

--- a/tests/TestHelpers/DependencyContainer/RequestFactoryAwareEventDispatcher.php
+++ b/tests/TestHelpers/DependencyContainer/RequestFactoryAwareEventDispatcher.php
@@ -15,7 +15,7 @@ final class RequestFactoryAwareEventDispatcher implements EventDispatcherInterfa
      */
     public $requestFactory = null;
 
-    public function dispatch(object $event, string $eventName = null): object
+    public function dispatch(object $event, ?string $eventName = null): object
     {
         return new stdClass();
     }
@@ -41,7 +41,7 @@ final class RequestFactoryAwareEventDispatcher implements EventDispatcherInterfa
     {
     }
 
-    public function getListeners(string $eventName = null): array
+    public function getListeners(?string $eventName = null): array
     {
         return [];
     }
@@ -51,7 +51,7 @@ final class RequestFactoryAwareEventDispatcher implements EventDispatcherInterfa
         return null;
     }
 
-    public function hasListeners(string $eventName = null): bool
+    public function hasListeners(?string $eventName = null): bool
     {
         return false;
     }

--- a/tests/UnleashBuilderTest.php
+++ b/tests/UnleashBuilderTest.php
@@ -769,7 +769,7 @@ final class UnleashBuilderTest extends TestCase
     public function testWithMetricsHandler()
     {
         $metricsHandler = new class implements MetricsHandler {
-            public function handleMetrics(Feature $feature, bool $successful, Variant $variant = null): void
+            public function handleMetrics(Feature $feature, bool $successful, ?Variant $variant = null): void
             {
             }
         };


### PR DESCRIPTION
# Description

Implicitly nullable types are deprecated as of PHP 8.4 released a few days ago.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
