### PR TITLE
Chore: Ignore false positive from PHPStan

### DIFF
--- a/src/DTO/DefaultVariant.php
+++ b/src/DTO/DefaultVariant.php
@@ -99,6 +99,7 @@ final readonly class DefaultVariant implements Variant
             $variant->getStickiness(),
             $variant->getPayload(),
             $variant->getOverrides(),
+            // @phpstan-ignore-next-line function.alreadyNarrowedType
             $featureEnabled ?? (method_exists($variant, 'isFeatureEnabled') ? $variant->isFeatureEnabled() : false),
         );
     }


### PR DESCRIPTION
# Description

Because #241 and #213 were merged at the same time, a new error (false positive) occurred. It's now ignored.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Static analysis

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
