### PR TITLE
chore: add support for symfony v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "lastguest/murmurhash": "^2.1",
         "psr/http-message": "^1.0 | ^2.0",
         "php-http/discovery": "^1.14",
-        "symfony/event-dispatcher": "^5.0 | ^6.0 | ^7.0"
+        "symfony/event-dispatcher": "^5.0 | ^6.0 | ^7.0 | ^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -36,9 +36,9 @@
         "jetbrains/phpstorm-attributes": "^1.0",
         "rector/rector": "^2.0",
         "phpunit/phpunit": "^9.5",
-        "symfony/http-client": "^5.0 | ^6.0 | ^7.0",
+        "symfony/http-client": "^5.0 | ^6.0 | ^7.0 | ^8.0",
         "nyholm/psr7": "^1.0",
-        "symfony/cache": "^5.0 | ^6.0 | ^7.0"
+        "symfony/cache": "^5.0 | ^6.0 | ^7.0 | ^8.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,9 +9,6 @@ parameters:
         - '#Class .+Flysystem.* not found#'
       path: src/Helper/DefaultImplementationLocator.php
       reportUnmatched: false
-    - messages:
-        - '#is never assigned (.+) so it can be removed from the property type#'
-      path: src/UnleashBuilder.php
   treatPhpDocTypesAsCertain: false
 rules:
   - Unleash\Client\PhpstanRules\NoEmptyFunctionRule

--- a/tests/DefaultUnleashTest.php
+++ b/tests/DefaultUnleashTest.php
@@ -649,7 +649,7 @@ final class DefaultUnleashTest extends AbstractHttpClientTestCase
                 $this->calledCount = &$calledCount;
             }
 
-            public static function getSubscribedEvents()
+            public static function getSubscribedEvents(): array
             {
                 return [UnleashEvents::FEATURE_TOGGLE_MISSING_STRATEGY_HANDLER => 'onNoStrategyHandler'];
             }


### PR DESCRIPTION
Seems like this package is not affected by any BC breaking changes documented in https://github.com/symfony/symfony/blob/8.0/UPGRADE-8.0.md
