### PR TITLE
Make 8.5 the main PHP version

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.5
       - name: Checkout Code
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
       - name: Extract Version Name
         id: extract_name
         uses: actions/github-script@v7
@@ -32,17 +32,17 @@ jobs:
       - name: Create latest release tag
         env:
           VERSION: ${{ steps.extract_name.outputs.result }}
-        run: git tag v${VERSION}84
+        run: git tag v${VERSION}85
       - name: Push latest release tag
         env:
           VERSION: ${{ steps.extract_name.outputs.result }}
-        run: git push origin v${VERSION}84
+        run: git push origin v${VERSION}85
   release_older:
     name: Release older PHP version
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Extract Version Name
         id: extract_name
@@ -54,7 +54,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.5
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Install Dependencies
@@ -69,7 +69,7 @@ jobs:
         if: matrix.version == '7.2'
         run: composer require symfony/polyfill-php73:^1.0
       - name: Update composer.json version
-        run: 'sed -i -e ''s/"php": "\^8.4"/"php": "\^${{ matrix.version }}"/'' composer.json'
+        run: 'sed -i -e ''s/"php": "\^8.5"/"php": "\^${{ matrix.version }}"/'' composer.json'
       - name: Downgrade phpunit
         if: matrix.version == '7.2'
         run: 'sed -i -e ''s/"phpunit\/phpunit": "\^9.5"/"phpunit\/phpunit": "\^8.5"/'' composer.json'

--- a/.github/workflows/tests-8.x.yaml
+++ b/.github/workflows/tests-8.x.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['8.0', '8.1', '8.2', '8.3']
+        version: ['8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: Tests (8.4)
+name: Tests (8.5)
 on:
   push:
     branches:
@@ -14,7 +14,7 @@ jobs:
       PHP_CS_FIXER_IGNORE_ENV: 1
     strategy:
       matrix:
-        version: ['8.4']
+        version: ['8.5']
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['8.4']
+        version: ['8.5']
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['8.4']
+        version: ['8.5']
         optional-deps: ['', 'cache/filesystem-adapter:^1.1']
     steps:
       - name: Setup PHP
@@ -73,12 +73,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Setup Build PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.5
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
@@ -91,7 +91,7 @@ jobs:
         if: matrix.version == '7.2'
         run: composer require symfony/polyfill-php73:^1.0
       - name: Update composer.json version
-        run: 'sed -i -e ''s/"php": "\^8.4"/"php": "\^${{ matrix.version }}"/'' composer.json'
+        run: 'sed -i -e ''s/"php": "\^8.5"/"php": "\^${{ matrix.version }}"/'' composer.json'
       - name: Downgrade phpunit
         if: matrix.version == '7.2'
         run: 'sed -i -e ''s/"phpunit\/phpunit": "\^9.5"/"phpunit\/phpunit": "\^8.5"/'' composer.json'

--- a/.github/workflows/transpile.yaml
+++ b/.github/workflows/transpile.yaml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.5
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Install Dependencies
@@ -27,7 +27,7 @@ jobs:
         if: matrix.version == '7.2'
         run: composer require symfony/polyfill-php73:^1.0
       - name: Update composer.json version
-        run: 'sed -i -e ''s/"php": "\^8.4"/"php": "\^${{ matrix.version }}"/'' composer.json'
+        run: 'sed -i -e ''s/"php": "\^8.5"/"php": "\^${{ matrix.version }}"/'' composer.json'
       - name: Downgrade phpunit
         if: matrix.version == '7.2'
         run: 'sed -i -e ''s/"phpunit\/phpunit": "\^9.5"/"phpunit\/phpunit": "\^8.5"/'' composer.json'

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.4",
+        "php": "^8.5",
         "ext-json": "*",
         "psr/http-client": "^1.0",
         "psr/http-client-implementation": "^1.0",

--- a/rector.84.php
+++ b/rector.84.php
@@ -1,0 +1,10 @@
+<?php
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\DowngradeLevelSetList;
+
+return static function (RectorConfig $config): void {
+    $config->sets([
+        DowngradeLevelSetList::DOWN_TO_PHP_84,
+    ]);
+};

--- a/rector.php
+++ b/rector.php
@@ -19,5 +19,6 @@ return static function (RectorConfig $config): void {
         SetList::PHP_82,
         SetList::PHP_83,
         SetList::PHP_84,
+        SetList::PHP_85,
     ]);
 };

--- a/tests/Helper/NetworkCalculatorTest.php
+++ b/tests/Helper/NetworkCalculatorTest.php
@@ -77,7 +77,9 @@ final class NetworkCalculatorTest extends TestCase
     {
         $reflection = new ReflectionObject($calculator);
         $property = $reflection->getProperty('ipAddress');
-        $property->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
 
         return $property->getValue($calculator);
     }
@@ -86,7 +88,9 @@ final class NetworkCalculatorTest extends TestCase
     {
         $reflection = new ReflectionObject($calculator);
         $property = $reflection->getProperty('networkSize');
-        $property->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
 
         return $property->getValue($calculator);
     }

--- a/tests/UnleashBuilderTest.php
+++ b/tests/UnleashBuilderTest.php
@@ -90,7 +90,9 @@ final class UnleashBuilderTest extends TestCase
     {
         self::assertNotSame($this->instance, $this->instance->withStrategies(new DefaultStrategyHandler()));
         $strategiesProperty = (new ReflectionObject($this->instance))->getProperty('strategies');
-        $strategiesProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $strategiesProperty->setAccessible(true);
+        }
 
         self::assertCount(8, $strategiesProperty->getValue($this->instance));
         $instance = $this->instance->withStrategies(new class implements StrategyHandler {
@@ -166,14 +168,20 @@ final class UnleashBuilderTest extends TestCase
             ->build();
         $reflection = new ReflectionObject($instance);
         $repositoryProperty = $reflection->getProperty('repository');
-        $repositoryProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $repositoryProperty->setAccessible(true);
+        }
         $repository = $repositoryProperty->getValue($instance);
         $strategiesProperty = $reflection->getProperty('strategyHandlers');
-        $strategiesProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $strategiesProperty->setAccessible(true);
+        }
         $strategies = $strategiesProperty->getValue($instance);
         $reflection = new ReflectionObject($repository);
         $configurationProperty = $reflection->getProperty('configuration');
-        $configurationProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $configurationProperty->setAccessible(true);
+        }
         $configuration = $configurationProperty->getValue($repository);
         assert($configuration instanceof UnleashConfiguration);
 
@@ -197,9 +205,13 @@ final class UnleashBuilderTest extends TestCase
             ->build();
         $repository = new ReflectionObject($repositoryProperty->getValue($instance));
         $httpClientProperty = $repository->getProperty('httpClient');
-        $httpClientProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $httpClientProperty->setAccessible(true);
+        }
         $requestFactoryProperty = $repository->getProperty('requestFactory');
-        $requestFactoryProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $requestFactoryProperty->setAccessible(true);
+        }
         self::assertEquals($httpClient, $httpClientProperty->getValue($repositoryProperty->getValue($instance)));
         self::assertEquals($requestFactory, $requestFactoryProperty->getValue($repositoryProperty->getValue($instance)));
 
@@ -242,7 +254,9 @@ final class UnleashBuilderTest extends TestCase
             ->withHeader('Some-Header', 'test');
         $reflection = new ReflectionObject($instance);
         $headersProperty = $reflection->getProperty('headers');
-        $headersProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $headersProperty->setAccessible(true);
+        }
         $headers = $headersProperty->getValue($instance);
         self::assertCount(2, $headers);
 
@@ -261,17 +275,23 @@ final class UnleashBuilderTest extends TestCase
             ->build();
         $reflection = new ReflectionObject($unleash);
         $repositoryProperty = $reflection->getProperty('repository');
-        $repositoryProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $repositoryProperty->setAccessible(true);
+        }
         $repository = $repositoryProperty->getValue($unleash);
 
         $reflection = new ReflectionObject($repository);
         $configurationProperty = $reflection->getProperty('configuration');
-        $configurationProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $configurationProperty->setAccessible(true);
+        }
         $configuration = $configurationProperty->getValue($repository);
 
         $reflection = new ReflectionObject($configuration);
         $headersPropertyBuilt = $reflection->getProperty('headers');
-        $headersPropertyBuilt->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $headersPropertyBuilt->setAccessible(true);
+        }
         $headersBuilt = $headersPropertyBuilt->getValue($configuration);
         self::assertEquals($headers, $headersBuilt);
 
@@ -306,7 +326,9 @@ final class UnleashBuilderTest extends TestCase
         $instance = $this->instance->withGitlabEnvironment('Test');
         $reflection = new ReflectionObject($instance);
         $appNameProperty = $reflection->getProperty('appName');
-        $appNameProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $appNameProperty->setAccessible(true);
+        }
         self::assertEquals('Test', $appNameProperty->getValue($instance));
     }
 
@@ -331,15 +353,21 @@ final class UnleashBuilderTest extends TestCase
         $unleash = $instance->build();
 
         $locatorProperty = (new ReflectionObject($instance))->getProperty('defaultImplementationLocator');
-        $locatorProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $locatorProperty->setAccessible(true);
+        }
         $locator = $locatorProperty->getValue($instance);
 
         $repositoryProperty = (new ReflectionObject($unleash))->getProperty('repository');
-        $repositoryProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $repositoryProperty->setAccessible(true);
+        }
         $repository = $repositoryProperty->getValue($unleash);
 
         $httpClientProperty = (new ReflectionObject($repository))->getProperty('httpClient');
-        $httpClientProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $httpClientProperty->setAccessible(true);
+        }
         $httpClient = $httpClientProperty->getValue($repository);
 
         self::assertInstanceOf(ClientInterface::class, $httpClient);
@@ -356,14 +384,20 @@ final class UnleashBuilderTest extends TestCase
         Psr18ClientDiscovery::setStrategies($discoveryStrategies);
 
         $configurationProperty = (new ReflectionObject($repository))->getProperty('configuration');
-        $configurationProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $configurationProperty->setAccessible(true);
+        }
         $configuration = $configurationProperty->getValue($repository);
 
         $cacheProperty = (new ReflectionObject($configuration))->getProperty('cache');
-        $cacheProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $cacheProperty->setAccessible(true);
+        }
 
         $defaultImplementationsProperty = (new ReflectionObject($locator))->getProperty('defaultImplementations');
-        $defaultImplementationsProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $defaultImplementationsProperty->setAccessible(true);
+        }
         $defaultImplementations = $defaultImplementationsProperty->getValue($locator);
 
         // cache/filesystem-adapter should be used by default if it's installed
@@ -408,9 +442,13 @@ final class UnleashBuilderTest extends TestCase
         $instance = UnleashBuilder::createForGitlab();
 
         $autoRegistrationProperty = (new ReflectionObject($instance))->getProperty('autoregister');
-        $autoRegistrationProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $autoRegistrationProperty->setAccessible(true);
+        }
         $metricsProperty = (new ReflectionObject($instance))->getProperty('metricsEnabled');
-        $metricsProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $metricsProperty->setAccessible(true);
+        }
 
         self::assertFalse($autoRegistrationProperty->getValue($instance));
         self::assertFalse($metricsProperty->getValue($instance));
@@ -419,7 +457,9 @@ final class UnleashBuilderTest extends TestCase
     public function testWithStrategy()
     {
         $strategiesProperty = (new ReflectionObject($this->instance))->getProperty('strategies');
-        $strategiesProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $strategiesProperty->setAccessible(true);
+        }
 
         self::assertCount(8, $strategiesProperty->getValue($this->instance));
         $instance = $this->instance->withStrategy(new class implements StrategyHandler {
@@ -448,7 +488,9 @@ final class UnleashBuilderTest extends TestCase
         $provider = new DefaultUnleashContextProvider();
         $instance = $this->instance->withContextProvider($provider);
         $providerProperty = (new ReflectionObject($instance))->getProperty('contextProvider');
-        $providerProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $providerProperty->setAccessible(true);
+        }
         self::assertSame($provider, $providerProperty->getValue($instance));
     }
 
@@ -894,17 +936,23 @@ final class UnleashBuilderTest extends TestCase
         $unleash = $base->build();
         $reflection = new ReflectionObject($unleash);
         $repositoryProperty = $reflection->getProperty('repository');
-        $repositoryProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $repositoryProperty->setAccessible(true);
+        }
         $repository = $repositoryProperty->getValue($unleash);
 
         $reflection = new ReflectionObject($repository);
         $configurationProperty = $reflection->getProperty('configuration');
-        $configurationProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $configurationProperty->setAccessible(true);
+        }
         $configuration = $configurationProperty->getValue($repository);
 
         $reflection = new ReflectionObject($configuration);
         $headersPropertyBuilt = $reflection->getProperty('headers');
-        $headersPropertyBuilt->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $headersPropertyBuilt->setAccessible(true);
+        }
         $headersBuilt = $headersPropertyBuilt->getValue($configuration);
         self::assertArrayHasKey('Authorization', $headersBuilt);
     }
@@ -1002,7 +1050,9 @@ final class UnleashBuilderTest extends TestCase
             ->buildRepository();
         $reflection = new ReflectionObject($repository);
         $configurationProperty = $reflection->getProperty('configuration');
-        $configurationProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $configurationProperty->setAccessible(true);
+        }
         $configuration = $configurationProperty->getValue($repository);
         assert($configuration instanceof UnleashConfiguration);
 
@@ -1025,9 +1075,13 @@ final class UnleashBuilderTest extends TestCase
             ->buildRepository();
         $reflection = new ReflectionObject($repository);
         $httpClientProperty = $reflection->getProperty('httpClient');
-        $httpClientProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $httpClientProperty->setAccessible(true);
+        }
         $requestFactoryProperty = $reflection->getProperty('requestFactory');
-        $requestFactoryProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $requestFactoryProperty->setAccessible(true);
+        }
         self::assertEquals($httpClient, $httpClientProperty->getValue($repository));
         self::assertEquals($requestFactory, $requestFactoryProperty->getValue($repository));
 
@@ -1043,7 +1097,9 @@ final class UnleashBuilderTest extends TestCase
 
         $reflection = new ReflectionObject($repository);
         $configurationProperty = $reflection->getProperty('configuration');
-        $configurationProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $configurationProperty->setAccessible(true);
+        }
         $configuration = $configurationProperty->getValue($repository);
         assert($configuration instanceof UnleashConfiguration);
         self::assertEquals($cacheHandler, $configuration->getCache());
@@ -1053,7 +1109,9 @@ final class UnleashBuilderTest extends TestCase
     private function getConfiguration(DefaultUnleash $unleash): UnleashConfiguration
     {
         $configurationProperty = (new ReflectionObject($unleash))->getProperty('configuration');
-        $configurationProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $configurationProperty->setAccessible(true);
+        }
 
         return $configurationProperty->getValue($unleash);
     }
@@ -1081,7 +1139,9 @@ final class UnleashBuilderTest extends TestCase
     private function getProperty(object $object, string $property)
     {
         $property = $this->getReflection($object)->getProperty($property);
-        $property->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
 
         return $property->getValue($object);
     }


### PR DESCRIPTION
# Description

* Changes the default, dev version to PHP 8.5, adds transpilation to PHP 8.4.
* Fixes deprecated `setAccessible()` calls which are [noop since PHP 8.1](https://wiki.php.net/rfc/make-reflection-setaccessible-no-op).

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
