### PR TITLE
fix: rename sdkFlavour and sdkFlavourVersion

### DIFF
--- a/src/Configuration/UnleashConfiguration.php
+++ b/src/Configuration/UnleashConfiguration.php
@@ -334,7 +334,7 @@ final class UnleashConfiguration
     }
 
     /**
-     * @return array{sdkFlavour?: string, sdkFlavourVersion?: string}
+     * @return array{sdkFlavor?: string, sdkFlavorVersion?: string}
      */
     public function getSdkFlavourMetadata(): array
     {
@@ -343,8 +343,8 @@ final class UnleashConfiguration
         }
 
         return [
-            'sdkFlavour' => $this->sdkFlavour,
-            'sdkFlavourVersion' => $this->sdkFlavourVersion,
+            'sdkFlavor' => $this->sdkFlavour,
+            'sdkFlavorVersion' => $this->sdkFlavourVersion,
         ];
     }
 }

--- a/tests/Client/DefaultRegistrationServiceTest.php
+++ b/tests/Client/DefaultRegistrationServiceTest.php
@@ -173,7 +173,7 @@ final class DefaultRegistrationServiceTest extends AbstractHttpClientTestCase
         $request = $this->requestHistory[0]['request'];
         $payload = json_decode((string) $request->getBody(), true, 512, JSON_THROW_ON_ERROR);
 
-        self::assertSame('test-wrapper', $payload['sdkFlavour']);
-        self::assertSame('2.3.4', $payload['sdkFlavourVersion']);
+        self::assertSame('test-wrapper', $payload['sdkFlavor']);
+        self::assertSame('2.3.4', $payload['sdkFlavorVersion']);
     }
 }

--- a/tests/Configuration/UnleashConfigurationTest.php
+++ b/tests/Configuration/UnleashConfigurationTest.php
@@ -71,8 +71,8 @@ final class UnleashConfigurationTest extends TestCase
         self::assertSame('test-wrapper', $instance->getSdkFlavour());
         self::assertSame('1.2.3', $instance->getSdkFlavourVersion());
         self::assertSame([
-            'sdkFlavour' => 'test-wrapper',
-            'sdkFlavourVersion' => '1.2.3',
+            'sdkFlavor' => 'test-wrapper',
+            'sdkFlavorVersion' => '1.2.3',
         ], $instance->getSdkFlavourMetadata());
     }
 

--- a/tests/Metrics/DefaultMetricsSenderTest.php
+++ b/tests/Metrics/DefaultMetricsSenderTest.php
@@ -81,7 +81,7 @@ final class DefaultMetricsSenderTest extends AbstractHttpClientTestCase
         $request = $this->requestHistory[0]['request'];
         $payload = json_decode((string) $request->getBody(), true, 512, JSON_THROW_ON_ERROR);
 
-        self::assertSame('test-wrapper', $payload['sdkFlavour']);
-        self::assertSame('3.4.5', $payload['sdkFlavourVersion']);
+        self::assertSame('test-wrapper', $payload['sdkFlavor']);
+        self::assertSame('3.4.5', $payload['sdkFlavorVersion']);
     }
 }


### PR DESCRIPTION
Headers in Unleash are spelled with American English :(

This should keep the public API intact and still fix the bug